### PR TITLE
Jinja2 templates in every card's own string fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ Alle nennenswerten Änderungen an diesem Projekt werden hier dokumentiert.
 Format angelehnt an [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 Versionierung folgt [SemVer](https://semver.org/lang/de/).
 
+## [Unreleased]
+
+### Added
+
+- **Jinja2 templates in every card's own string fields.** A field containing
+  `{{` or `{%` — a name, an icon, a colour, whatever that card reads out of its
+  config — is now subscribed over Home Assistant's `render_template` websocket
+  and pushed a new value whenever anything it reads changes. Until now a card
+  could show a fixed string or one entity's raw state and nothing else, so a
+  composed label meant a template-sensor helper in `configuration.yaml` for
+  every card that wanted one, and a dashboard moved over from mushroom lost
+  every templated label, icon and colour it had.
+
+  Templates inside a **nested** card config — `cards:`, a popup action's
+  content, a mushroom card in a slot — are deliberately left alone and handed
+  to that card verbatim. It renders them itself, and it renders them live;
+  resolving them here would freeze the field at whatever it said when the outer
+  card was configured. The walk stops at any nested object carrying its own
+  `type`.
+
+  Nothing changes for a card that uses no templates, and it costs nothing: no
+  walk, no subscription, no copy of its config. The nav card keeps its own
+  per-entry templates, including the boolean `hidden` / `disabled` fields.
+
+### Hinzugefügt
+
+- **Jinja2-Templates in allen eigenen Textfeldern jeder Karte.** Ein Feld mit
+  `{{` oder `{%` — Name, Icon, Farbe, was die Karte eben aus ihrer
+  Konfiguration liest — wird jetzt über den `render_template`-Websocket von Home
+  Assistant abonniert und bekommt einen neuen Wert gepusht, sobald sich etwas
+  ändert, das das Template liest. Bisher konnte eine Karte einen festen Text
+  oder den rohen Zustand einer Entität zeigen und sonst nichts: Für jede
+  zusammengesetzte Beschriftung brauchte es einen Template-Sensor-Helfer in der
+  `configuration.yaml`, und ein von Mushroom übernommenes Dashboard verlor jede
+  getemplatete Beschriftung, jedes Icon und jede Farbe.
+
+  Templates in **verschachtelten** Karten-Konfigurationen — `cards:`, der Inhalt
+  eines Popup-Actions, eine Mushroom-Karte in einem Slot — bleiben bewusst
+  unangetastet und gehen unverändert an diese Karte. Sie rendert sie selbst, und
+  zwar live; würden sie hier aufgelöst, fröre das Feld auf dem Wert ein, den es
+  beim Konfigurieren der äußeren Karte hatte. Der Durchlauf stoppt an jedem
+  verschachtelten Objekt mit eigenem `type`.
+
+  Für Karten ohne Templates ändert sich nichts, und es kostet nichts: kein
+  Durchlauf, kein Abo, keine Kopie der Konfiguration. Die Nav-Karte behält ihre
+  eigenen Templates pro Eintrag, samt der Wahrheitswert-Felder `hidden` /
+  `disabled`.
+
 ## [2.3.2]
 
 Editor tidying for the nav card, following 2.3.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,11 @@ before releases.
   per-card `animation` override.
 - Each card writes its own `card_version` into the config so future config
   migrations can be detected reliably (`src/shared/config-migration.ts`).
+- Every card class is declared as
+  `extends TemplatedCard(LitElement) implements LovelaceCard`
+  (`src/shared/templated-card.ts`). That is what gives its config fields Jinja2
+  support; a new card gets it by using the same declaration, and needs nothing
+  else — it goes on reading `this._config`, which arrives resolved.
 
 ## Pull requests
 

--- a/README.de.md
+++ b/README.de.md
@@ -118,6 +118,8 @@ Live-Werte.</sub>
   `animation: auto | on | off` erzwingbar
 - Alte Configs (z.B. `animations: true/false`) werden beim Laden automatisch
   auf das aktuelle Schema migriert — kein manuelles Nachpflegen nötig
+- [Jinja2-Templates](#templates) in allen eigenen Textfeldern jeder Karte, live
+  über den Websocket — kein Template-Sensor-Helfer pro Karte mehr
 
 ## Installation
 
@@ -142,6 +144,70 @@ dort auf *Herunterladen* drücken, fertig. Von Hand geht es so:
    *Einstellungen → Dashboards → Ressourcen → Ressource hinzufügen*
    - URL: `/local/m3-cards.js`
    - Typ: JavaScript-Modul
+
+## Templates
+
+Jede Karte akzeptiert Jinja2 in **ihren eigenen Textfeldern** — Name, Icon,
+Farbe, Einheit, was die jeweilige Karte eben aus ihrer Konfiguration liest. Ein
+Feld gilt als Template, sobald es `{{` oder `{%` enthält; alles andere bleibt
+unangetastet.
+
+```yaml
+type: custom:m3-button-card
+entity: light.kitchen
+name: "{{ states('sensor.kitchen_temperature') | round(1) }} °C"
+icon: >-
+  {{ 'mdi:lightbulb-on' if is_state('light.kitchen', 'on') else 'mdi:lightbulb' }}
+```
+
+Vorher konnte ein Feld nur ein fester Text oder der rohe Zustand einer Entität
+sein. Für jede zusammengesetzte Beschriftung brauchte es einen
+Template-Sensor-Helfer in der `configuration.yaml` — und ein Icon, das von einer
+Entität abhängt, ließ sich überhaupt nicht ausdrücken:
+
+```yaml
+# configuration.yaml — einer davon pro Karte, jetzt nicht mehr nötig
+template:
+  - sensor:
+      - name: Kitchen label
+        state: "{{ states('sensor.kitchen_temperature') | round(1) }} °C"
+```
+
+Die Werte werden **gepusht**, nicht gepollt: Die Karte abonniert das Template
+über den Websocket, und Home Assistant rendert es neu, sobald sich irgendetwas
+ändert, das das Template liest. Ein Abo pro unterschiedlichem Template — zwei
+Felder mit derselben Zeichenkette teilen sich eines —, und alle werden
+geschlossen, sobald die Karte die Seite verlässt.
+
+Eine Karte ohne Templates verhält sich exakt wie bisher und zahlt nichts dafür:
+Es wird nichts durchlaufen, abonniert oder kopiert.
+
+### Verschachtelte Karten bleiben unangetastet
+
+Karten-Konfigurationen können andere Karten enthalten: `cards:` bei Gruppen- und
+Raumkarte, der Inhalt eines Popup-Actions, eine Mushroom-Karte in einem Slot.
+**Templates darin werden hier nicht gerendert** — sie gehen unverändert an die
+Karte, der sie gehören.
+
+```yaml
+type: custom:m3-room-card
+area: kitchen
+name: "{{ states('sensor.kitchen_temperature') | round(1) }} °C"   # hier gerendert
+cards:
+  - type: custom:mushroom-template-card
+    primary: "{{ states('sensor.kitchen_humidity') }} %"           # bleibt Mushroom
+```
+
+Der Grund: Die innere Karte rendert ihre Templates selbst, und zwar *live*.
+Würde `primary` oben hier aufgelöst, bekäme Mushroom genau die eine Zeichenkette,
+die zum Zeitpunkt der Konfiguration herauskam — das Feld würde auf diesem Wert
+einfrieren und dem Sensor nie wieder folgen. Die Regel ist mechanisch: Der Durchlauf
+stoppt an jedem verschachtelten Objekt mit eigenem `type`, denn so sieht eine
+Karten-Konfiguration aus, egal für welche Karte.
+
+Die Nav-Karte ist die Ausnahme in die andere Richtung: Ihre Einträge hatten
+Templates schon vorher, mit `hidden` / `disabled` als Wahrheitswerte, und sie
+funktionieren wie unter [M3 Nav Card](#m3-nav-card) beschrieben.
 
 ## M3 Climate Card
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ the image — everything else is live data.</sub>
   per card via `animation: auto | on | off`
 - Old configs (e.g. `animations: true/false`) are migrated to the current
   schema automatically on load — no manual dashboard edits needed
+- [Jinja2 templates](#templates) in every card's own string fields, live over
+  the websocket — no template-sensor helper per card
 
 ## Installation
 
@@ -145,6 +147,69 @@ The button opens the repository straight in your own Home Assistant — press
    *Settings → Dashboards → Resources → Add resource*
    - URL: `/local/m3-cards.js`
    - Type: JavaScript module
+
+## Templates
+
+Every card accepts Jinja2 in **its own string fields** — name, icon, colour,
+unit, whatever that card reads out of its config. A field is treated as a
+template as soon as it contains `{{` or `{%`; everything else is left alone.
+
+```yaml
+type: custom:m3-button-card
+entity: light.kitchen
+name: "{{ states('sensor.kitchen_temperature') | round(1) }} °C"
+icon: >-
+  {{ 'mdi:lightbulb-on' if is_state('light.kitchen', 'on') else 'mdi:lightbulb' }}
+```
+
+Before, a field could only be a fixed string or one entity's raw state. A
+composed label meant a template-sensor helper in `configuration.yaml` for every
+card that wanted one — and an icon that depends on an entity had no way to be
+expressed at all:
+
+```yaml
+# configuration.yaml — one of these per card, no longer needed
+template:
+  - sensor:
+      - name: Kitchen label
+        state: "{{ states('sensor.kitchen_temperature') | round(1) }} °C"
+```
+
+Values are **pushed**, not polled: the card subscribes to the template over
+Home Assistant's websocket, and Home Assistant re-renders it whenever anything
+the template reads changes. One subscription per distinct template — two fields
+sharing the same string share one — and they are all closed when the card
+leaves the page.
+
+A card that uses no templates behaves exactly as it always has and pays nothing
+for the feature: nothing is walked, subscribed or copied.
+
+### Nested cards are left alone
+
+Card configs can contain other cards: `cards:` on the group and room cards, the
+content of a popup action, a mushroom card dropped into a slot. **Templates
+inside those are not rendered here** — they are passed through untouched to the
+card they belong to.
+
+```yaml
+type: custom:m3-room-card
+area: kitchen
+name: "{{ states('sensor.kitchen_temperature') | round(1) }} °C"   # rendered here
+cards:
+  - type: custom:mushroom-template-card
+    primary: "{{ states('sensor.kitchen_humidity') }} %"           # left for mushroom
+```
+
+The reason is that the inner card renders its own templates, and it renders
+them *live*. Resolving `primary` above would hand mushroom the one string it
+happened to say at the moment the room card was configured — the field would
+freeze at that value and never follow the sensor again. The rule is mechanical:
+the walk stops at any nested object that carries its own `type`, which is what
+a card config looks like whatever card it is for.
+
+The nav card is the exception in the other direction: its entries had templates
+before this existed, with `hidden` / `disabled` read as booleans, and they work
+as documented under [M3 Nav Card](#m3-nav-card).
 
 ## M3 Climate Card
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -76,6 +76,9 @@ implementiert sind. Ein Fehlschlag hier betrifft potenziell alle Karten gleichze
 | C13 | Sprachumschaltung | HA-Profil-Sprache zwischen Deutsch und Englisch wechseln | Alle Karten-Texte (inkl. Editor-Labels) wechseln vollständig, keine deutschen Reste im Englischen oder umgekehrt |
 | C14 | Grid-Optionen (Sections-Dashboard) | Karte auf einem Sections-Dashboard platzieren, Größe ändern | Karte skaliert sinnvoll, `getGridOptions` liefert plausible Min/Max-Werte |
 | C15 | Konsole sauber | Nach jedem der obigen Schritte | `read_console_messages`/DevTools zeigen keine Fehler mit `m3-cards.js` als Quelle |
+| C16 | Jinja2-Template in einem Feld | `name: "{{ states('sensor.x') }}"` (o. ä. Textfeld) setzen, dann `sensor.x` in den Dev-Tools ändern | Feld zeigt den gerenderten Wert und aktualisiert sich beim Zustandswechsel ohne Reload; kein Abo-Aufbau bei jedem State-Tick (Netzwerk-Tab: eine `render_template`-Nachricht pro unterschiedlichem Template) |
+| C17 | Template in verschachtelter Karte | In `cards:` (bzw. Popup-Inhalt) eine `custom:mushroom-template-card` mit eigenem Template legen | Die innere Karte rendert ihr Template weiterhin selbst und folgt ihrem Sensor — der Wert friert nicht auf dem Stand beim Laden ein |
+| C18 | Karte ohne Templates | Beliebige Karte ohne `{{`/`{%` in der Config laden | Verhalten unverändert; im Netzwerk-Tab kein `render_template` für diese Karte |
 
 ## M3 Climate Card
 

--- a/src/m3-aquarium-card.ts
+++ b/src/m3-aquarium-card.ts
@@ -64,6 +64,7 @@ import { fireEvent } from "./shared/editor-helpers";
 import { formatNumber } from "./shared/formatting";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-AQUARIUM-CARD %c v${CARD_VERSION} `,
@@ -132,7 +133,7 @@ interface AquariumTile {
 }
 
 @customElement("m3-aquarium-card")
-export class M3AquariumCard extends LitElement implements LovelaceCard {
+export class M3AquariumCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3AquariumCardConfig;

--- a/src/m3-battery-card.ts
+++ b/src/m3-battery-card.ts
@@ -52,6 +52,7 @@ import { discoverBatteryEntities } from "./shared/ha-registry";
 import { activateOnKey } from "./shared/a11y";
 import { localize, type TranslationKey } from "./localize";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-BATTERY-CARD %c v${CARD_VERSION} `,
@@ -83,7 +84,7 @@ const STAGE_ORDER: Record<BatteryStage, number> = {
 };
 
 @customElement("m3-battery-card")
-export class M3BatteryCard extends LitElement implements LovelaceCard {
+export class M3BatteryCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3BatteryCardConfig;

--- a/src/m3-button-card.ts
+++ b/src/m3-button-card.ts
@@ -35,6 +35,7 @@ import {
   fillColor,
   inkOn,
 } from "./shared/color-config";
+import { TemplatedCard } from "./shared/templated-card";
 
 const HOLD_DURATION_MS = 500;
 const DOUBLE_TAP_WINDOW_MS = 250;
@@ -55,7 +56,7 @@ function _isNotDisabled(action?: HaActionConfig): boolean {
 }
 
 @customElement("m3-button-card")
-export class M3ButtonCard extends LitElement implements LovelaceCard {
+export class M3ButtonCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3ButtonCardConfig;

--- a/src/m3-calendar-card.ts
+++ b/src/m3-calendar-card.ts
@@ -85,6 +85,7 @@ import {
 } from "./shared/ha-calendar";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters, listEntities } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-CALENDAR-CARD %c v${CARD_VERSION} `,
@@ -109,7 +110,7 @@ interface DayGroup {
 }
 
 @customElement("m3-calendar-card")
-export class M3CalendarCard extends LitElement implements LovelaceCard {
+export class M3CalendarCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3CalendarCardConfig;

--- a/src/m3-chip-buttons-card.ts
+++ b/src/m3-chip-buttons-card.ts
@@ -14,9 +14,10 @@ import { resolveThemeColor } from "./shared/color-config";
 import { glassCardStyles, glassCardClass } from "./shared/glass-card";
 import { chipButtonsStyles, renderChipButtons } from "./shared/chip-buttons";
 import { TapHoldGesture } from "./shared/gestures";
+import { TemplatedCard } from "./shared/templated-card";
 
 @customElement("m3-chip-buttons-card")
-export class M3ChipButtonsCard extends LitElement implements LovelaceCard {
+export class M3ChipButtonsCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3ChipButtonsCardConfig;

--- a/src/m3-climate-card-mini.ts
+++ b/src/m3-climate-card-mini.ts
@@ -25,6 +25,7 @@ import { shouldAnimate } from "./shared/animation";
 import { migrateAnimationsField } from "./shared/config-migration";
 import { activateOnKey } from "./shared/a11y";
 import { tintOn, foregroundOn } from "./shared/color-config";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-CLIMATE-CARD-MINI %c v${CARD_VERSION} `,
@@ -33,7 +34,7 @@ console.info(
 );
 
 @customElement("m3-climate-card-mini")
-export class M3ClimateCardMini extends LitElement implements LovelaceCard {
+export class M3ClimateCardMini extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3ClimateCardMiniConfig;

--- a/src/m3-climate-card.ts
+++ b/src/m3-climate-card.ts
@@ -30,6 +30,7 @@ import { tintOn } from "./shared/color-config";
 import { shouldAnimate } from "./shared/animation";
 import { migrateAnimationsField } from "./shared/config-migration";
 import { activateOnKey } from "./shared/a11y";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-CLIMATE-CARD %c v${CARD_VERSION} `,
@@ -38,7 +39,7 @@ console.info(
 );
 
 @customElement("m3-climate-card")
-export class M3ClimateCard extends LitElement implements LovelaceCard {
+export class M3ClimateCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3ClimateCardConfig;

--- a/src/m3-climate-overview-card.ts
+++ b/src/m3-climate-overview-card.ts
@@ -56,6 +56,7 @@ import { formatNumber } from "./shared/formatting";
 import { guessRoomIcon } from "./shared/room-icons";
 import { localize, type TranslationKey } from "./localize";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-CLIMATE-OVERVIEW-CARD %c v${CARD_VERSION} `,
@@ -84,7 +85,7 @@ interface ClimateOverviewTile {
 
 
 @customElement("m3-climate-overview-card")
-export class M3ClimateOverviewCard extends LitElement implements LovelaceCard {
+export class M3ClimateOverviewCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3ClimateOverviewCardConfig;

--- a/src/m3-clock-card.ts
+++ b/src/m3-clock-card.ts
@@ -102,6 +102,7 @@ import {
   sharedFittedRadius,
 } from "./shared/shapes";
 import { VisibleTicker } from "./shared/visible-ticker";
+import { TemplatedCard } from "./shared/templated-card";
 
 const EASING = unsafeCSS(STANDARD_EASING);
 
@@ -120,7 +121,7 @@ interface ClockParts {
 }
 
 @customElement("m3-clock-card")
-export class M3ClockCard extends LitElement implements LovelaceCard {
+export class M3ClockCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3ClockCardConfig;

--- a/src/m3-cost-card.ts
+++ b/src/m3-cost-card.ts
@@ -51,6 +51,7 @@ import { activateOnKey } from "./shared/a11y";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
 import { formatNumber } from "./shared/formatting";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-COST-CARD %c v${CARD_VERSION} `,
@@ -128,7 +129,7 @@ function bucketize(dayMap: Map<string, number>, window: PeriodWindow): number[] 
 }
 
 @customElement("m3-cost-card")
-export class M3CostCard extends LitElement implements LovelaceCard {
+export class M3CostCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3CostCardConfig;

--- a/src/m3-counter-card.ts
+++ b/src/m3-counter-card.ts
@@ -41,6 +41,7 @@ import { fireEvent } from "./shared/editor-helpers";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
 import { decimalSeparator, formatNumber } from "./shared/formatting";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-COUNTER-CARD %c v${CARD_VERSION} `,
@@ -55,7 +56,7 @@ interface DigitCell {
 }
 
 @customElement("m3-counter-card")
-export class M3CounterCard extends LitElement implements LovelaceCard {
+export class M3CounterCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3CounterCardConfig;

--- a/src/m3-cover-card.ts
+++ b/src/m3-cover-card.ts
@@ -28,6 +28,7 @@ import { fireEvent } from "./shared/editor-helpers";
 import { buildWavePath } from "./shared/wave";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters, listEntities } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-COVER-CARD %c v${CARD_VERSION} `,
@@ -56,7 +57,7 @@ interface CoverModel {
 }
 
 @customElement("m3-cover-card")
-export class M3CoverCard extends LitElement implements LovelaceCard {
+export class M3CoverCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3CoverCardConfig;

--- a/src/m3-energy-card.ts
+++ b/src/m3-energy-card.ts
@@ -57,6 +57,7 @@ import { shouldAnimate } from "./shared/animation";
 import { localize, type TranslationKey } from "./localize";
 import { formatNumber } from "./shared/formatting";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-ENERGY-CARD %c v${CARD_VERSION} `,
@@ -79,7 +80,7 @@ interface BarValue {
 }
 
 @customElement("m3-energy-card")
-export class M3EnergyCard extends LitElement implements LovelaceCard {
+export class M3EnergyCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3EnergyCardConfig;

--- a/src/m3-energy-flow-card.ts
+++ b/src/m3-energy-flow-card.ts
@@ -45,6 +45,7 @@ import { getEnergyDashboardEntities, fetchTodayChangeSum } from "./shared/ha-ene
 import { localize, type TranslationKey } from "./localize";
 import { formatNumber } from "./shared/formatting";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-ENERGY-FLOW-CARD %c v${CARD_VERSION} `,
@@ -93,7 +94,7 @@ function straightPath(x1: number, y1: number, x2: number, y2: number): string {
 }
 
 @customElement("m3-energy-flow-card")
-export class M3EnergyFlowCard extends LitElement implements LovelaceCard {
+export class M3EnergyFlowCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3EnergyFlowCardConfig;

--- a/src/m3-gauge-card.ts
+++ b/src/m3-gauge-card.ts
@@ -32,6 +32,7 @@ import { shouldAnimate } from "./shared/animation";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
 import { formatNumber } from "./shared/formatting";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-GAUGE-CARD %c v${CARD_VERSION} `,
@@ -62,7 +63,7 @@ function arcPath(tStart: number, tEnd: number): string {
 }
 
 @customElement("m3-gauge-card")
-export class M3GaugeCard extends LitElement implements LovelaceCard {
+export class M3GaugeCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3GaugeCardConfig;

--- a/src/m3-group-card.ts
+++ b/src/m3-group-card.ts
@@ -11,6 +11,7 @@ import { DEFAULT_GROUP_RADIUS, DEFAULT_GROUP_GAP, resolveCornerRadius } from "./
 import { resolveThemeColor } from "./shared/color-config";
 import { glassCardStyles, glassCardClass } from "./shared/glass-card";
 import { GroupChildrenController } from "./shared/group-children";
+import { TemplatedCard } from "./shared/templated-card";
 
 // Wraps arbitrary Lovelace cards in one shared frame instead of each keeping
 // its own. The frame suppression itself lives in shared/glass-card.ts (a
@@ -19,7 +20,7 @@ import { GroupChildrenController } from "./shared/group-children";
 // build/host the child card elements and lay them out.
 
 @customElement("m3-group-card")
-export class M3GroupCard extends LitElement implements LovelaceCard {
+export class M3GroupCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3GroupCardConfig;

--- a/src/m3-heading-card.ts
+++ b/src/m3-heading-card.ts
@@ -49,6 +49,7 @@ import {
 } from "./shared/color-config";
 import { readCollapsed, writeCollapsed, type CollapseTarget } from "./shared/collapse-state";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 const EASING = unsafeCSS(STANDARD_EASING);
 
@@ -61,7 +62,7 @@ console.info(
 const STORAGE_PREFIX = "m3-heading-collapsed";
 
 @customElement("m3-heading-card")
-export class M3HeadingCard extends LitElement implements LovelaceCard {
+export class M3HeadingCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3HeadingCardConfig;

--- a/src/m3-humidifier-card.ts
+++ b/src/m3-humidifier-card.ts
@@ -74,6 +74,7 @@ import { buildWavePath, lerpStep } from "./shared/wave";
 import { localize, type TranslationKey } from "./localize";
 import { formatNumber } from "./shared/formatting";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-HUMIDIFIER-CARD %c v${CARD_VERSION} `,
@@ -129,7 +130,7 @@ function prettify(raw: string): string {
 }
 
 @customElement("m3-humidifier-card")
-export class M3HumidifierCard extends LitElement implements LovelaceCard {
+export class M3HumidifierCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3HumidifierCardConfig;

--- a/src/m3-leak-card.ts
+++ b/src/m3-leak-card.ts
@@ -38,6 +38,7 @@ import { fireEvent } from "./shared/editor-helpers";
 import { discoverLeakSensors } from "./shared/ha-registry";
 import { localize, type TranslationKey } from "./localize";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-LEAK-CARD %c v${CARD_VERSION} `,
@@ -58,7 +59,7 @@ interface LeakRow {
 }
 
 @customElement("m3-leak-card")
-export class M3LeakCard extends LitElement implements LovelaceCard {
+export class M3LeakCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3LeakCardConfig;

--- a/src/m3-light-card.ts
+++ b/src/m3-light-card.ts
@@ -54,6 +54,7 @@ import { hexToHs, hsToRgb, rgbToHex, rgbToHs } from "./shared/color-picker";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
 import { DragThrottle } from "./shared/drag-throttle";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-LIGHT-CARD %c v${CARD_VERSION} `,
@@ -65,7 +66,7 @@ const EASING = unsafeCSS(STANDARD_EASING);
 const DEFAULT_SLIDER_WIDTH = 220;
 
 @customElement("m3-light-card")
-export class M3LightCard extends LitElement implements LovelaceCard {
+export class M3LightCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3LightCardConfig;

--- a/src/m3-lights-overview-card.ts
+++ b/src/m3-lights-overview-card.ts
@@ -48,6 +48,7 @@ import { DetailCardController } from "./shared/detail-card";
 import type { CardTemplateTokens } from "./shared/card-template";
 import { discoveryChangeMatters } from "./shared/should-update";
 import { localize, type TranslationKey } from "./localize";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-LIGHTS-OVERVIEW-CARD %c v${CARD_VERSION} `,
@@ -90,7 +91,7 @@ function configFilter(config: M3LightsOverviewCardConfig): EntityFilterConfig {
 }
 
 @customElement("m3-lights-overview-card")
-export class M3LightsOverviewCard extends LitElement implements LovelaceCard {
+export class M3LightsOverviewCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3LightsOverviewCardConfig;

--- a/src/m3-media-card.ts
+++ b/src/m3-media-card.ts
@@ -77,6 +77,7 @@ import { stopSwipe } from "./shared/swipe";
 import { fireEvent } from "./shared/editor-helpers";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-MEDIA-CARD %c v${CARD_VERSION} `,
@@ -395,7 +396,7 @@ async function extractArtworkColor(url: string): Promise<string | undefined> {
 }
 
 @customElement("m3-media-card")
-export class M3MediaCard extends LitElement implements LovelaceCard {
+export class M3MediaCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3MediaCardConfig;

--- a/src/m3-nas-card.ts
+++ b/src/m3-nas-card.ts
@@ -43,6 +43,7 @@ import { shouldAnimate, STANDARD_EASING } from "./shared/animation";
 import { fireEvent } from "./shared/editor-helpers";
 import { localize, type TranslationKey } from "./localize";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-NAS-CARD %c v${CARD_VERSION} `,
@@ -171,7 +172,7 @@ export function prettyMount(mount: string): string {
 }
 
 @customElement("m3-nas-card")
-export class M3NasCard extends LitElement implements LovelaceCard {
+export class M3NasCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() protected _config?: M3NasCardConfig;

--- a/src/m3-occupancy-card.ts
+++ b/src/m3-occupancy-card.ts
@@ -53,6 +53,7 @@ import { discoverOccupancyRooms, type DiscoveredOccupancyRoom } from "./shared/h
 import { fetchOccupancySegments } from "./shared/occupancy-history";
 import { localize, type TranslationKey } from "./localize";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-OCCUPANCY-CARD %c v${CARD_VERSION} `,
@@ -78,7 +79,7 @@ interface OccupancyRow {
 }
 
 @customElement("m3-occupancy-card")
-export class M3OccupancyCard extends LitElement implements LovelaceCard {
+export class M3OccupancyCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3OccupancyCardConfig;

--- a/src/m3-power-list-card.ts
+++ b/src/m3-power-list-card.ts
@@ -41,6 +41,7 @@ import { renderListRow, captureRowRects, flipRows, listRowStyles } from "./share
 import { localize, type TranslationKey } from "./localize";
 import { formatNumber } from "./shared/formatting";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-POWER-LIST-CARD %c v${CARD_VERSION} `,
@@ -61,7 +62,7 @@ interface PowerRow {
 }
 
 @customElement("m3-power-list-card")
-export class M3PowerListCard extends LitElement implements LovelaceCard {
+export class M3PowerListCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3PowerListCardConfig;

--- a/src/m3-power-summary-card.ts
+++ b/src/m3-power-summary-card.ts
@@ -40,6 +40,7 @@ import { shouldAnimate } from "./shared/animation";
 import { fireEvent } from "./shared/editor-helpers";
 import { localize, type TranslationKey } from "./localize";
 import { formatNumber } from "./shared/formatting";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-POWER-SUMMARY-CARD %c v${CARD_VERSION} `,
@@ -50,7 +51,7 @@ console.info(
 type Direction = "export" | "import" | "neutral";
 
 @customElement("m3-power-summary-card")
-export class M3PowerSummaryCard extends LitElement implements LovelaceCard {
+export class M3PowerSummaryCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3PowerSummaryCardConfig;

--- a/src/m3-presence-card.ts
+++ b/src/m3-presence-card.ts
@@ -34,6 +34,7 @@ import { fireEvent } from "./shared/editor-helpers";
 import { localize, type TranslationKey } from "./localize";
 import { formatNumber } from "./shared/formatting";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-PRESENCE-CARD %c v${CARD_VERSION} `,
@@ -54,7 +55,7 @@ interface PersonRow {
 }
 
 @customElement("m3-presence-card")
-export class M3PresenceCard extends LitElement implements LovelaceCard {
+export class M3PresenceCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3PresenceCardConfig;

--- a/src/m3-progress-card.ts
+++ b/src/m3-progress-card.ts
@@ -29,6 +29,7 @@ import { hassChangeMatters } from "./shared/should-update";
 import { buildWavePath } from "./shared/wave";
 import { resolveCommonColors, tintOn, foregroundOn } from "./shared/color-config";
 import { glassCardStyles, glassCardClass, renderMissingEntity } from "./shared/glass-card";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-PROGRESS-CARD %c v${CARD_VERSION} `,
@@ -43,7 +44,7 @@ const AMPLITUDE_LERP = 0.12;
 const DEFAULT_BAR_WIDTH = 220;
 
 @customElement("m3-progress-card")
-export class M3ProgressCard extends LitElement implements LovelaceCard {
+export class M3ProgressCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3ProgressCardConfig;

--- a/src/m3-room-card.ts
+++ b/src/m3-room-card.ts
@@ -82,6 +82,7 @@ import { guessRoomIcon } from "./shared/room-icons";
 import { readCollapsed, writeCollapsed, type CollapseTarget } from "./shared/collapse-state";
 import { hassChangeMatters } from "./shared/should-update";
 import { createCards, updateCardsHass } from "./shared/card-helpers";
+import { TemplatedCard } from "./shared/templated-card";
 
 const EASING = unsafeCSS(STANDARD_EASING);
 
@@ -207,7 +208,7 @@ interface Chip {
 }
 
 @customElement("m3-room-card")
-export class M3RoomCard extends LitElement implements LovelaceCard {
+export class M3RoomCard extends TemplatedCard(LitElement) implements LovelaceCard {
   /**
    * A plain property would leave the cards inside the room card starved: they
    * take their data from a `hass` pushed onto them from outside, and the render

--- a/src/m3-status-card.ts
+++ b/src/m3-status-card.ts
@@ -73,6 +73,7 @@ import { glassCardClass, glassCardStyles } from "./shared/glass-card";
 import { formatNumber } from "./shared/formatting";
 import { fetchValueHoursAgo } from "./shared/ha-statistics";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 const EASING = unsafeCSS(STANDARD_EASING);
 
@@ -157,7 +158,7 @@ const PRESETS: Record<StatusPreset, StatusRule[]> = {
 const UNAVAILABLE_STATES = new Set(["unavailable", "unknown", "none", ""]);
 
 @customElement("m3-status-card")
-export class M3StatusCard extends LitElement implements LovelaceCard {
+export class M3StatusCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3StatusCardConfig;

--- a/src/m3-supply-card.ts
+++ b/src/m3-supply-card.ts
@@ -57,6 +57,7 @@ import { STANDARD_EASING, shouldAnimate } from "./shared/animation";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters, listEntities } from "./shared/should-update";
 import { formatNumber } from "./shared/formatting";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-SUPPLY-CARD %c v${CARD_VERSION} `,
@@ -87,7 +88,7 @@ interface SupplyEntry {
 }
 
 @customElement("m3-supply-card")
-export class M3SupplyCard extends LitElement implements LovelaceCard {
+export class M3SupplyCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3SupplyCardConfig;

--- a/src/m3-time-card.ts
+++ b/src/m3-time-card.ts
@@ -71,6 +71,7 @@ import {
 } from "./shared/ha-time";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-TIME-CARD %c v${CARD_VERSION} `,
@@ -99,7 +100,7 @@ function to12HourOrRaw(hours: number, twelveHour: boolean): number {
 }
 
 @customElement("m3-time-card")
-export class M3TimeCard extends LitElement implements LovelaceCard {
+export class M3TimeCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3TimeCardConfig;

--- a/src/m3-todo-card.ts
+++ b/src/m3-todo-card.ts
@@ -52,6 +52,7 @@ import { fetchTodoItems, todoSupports, TODO_FEATURE, type TodoItem } from "./sha
 import { collectSupplyChips } from "./shared/supply-chips";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-TODO-CARD %c v${CARD_VERSION} `,
@@ -71,7 +72,7 @@ function stripCategory(summary: string, label?: string): string {
 }
 
 @customElement("m3-todo-card")
-export class M3TodoCard extends LitElement implements LovelaceCard {
+export class M3TodoCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3TodoCardConfig;

--- a/src/m3-top-consumers-card.ts
+++ b/src/m3-top-consumers-card.ts
@@ -47,6 +47,7 @@ import { resolveEffectivePrice, formatCurrency } from "./shared/pricing";
 import { localize, type TranslationKey } from "./localize";
 import { formatNumber } from "./shared/formatting";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-TOP-CONSUMERS-CARD %c v${CARD_VERSION} `,
@@ -100,7 +101,7 @@ function cleanName(raw: string, patterns: string[]): string {
 }
 
 @customElement("m3-top-consumers-card")
-export class M3TopConsumersCard extends LitElement implements LovelaceCard {
+export class M3TopConsumersCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3TopConsumersCardConfig;

--- a/src/m3-updates-card.ts
+++ b/src/m3-updates-card.ts
@@ -54,6 +54,7 @@ import { fireEvent } from "./shared/editor-helpers";
 import { activateOnKey } from "./shared/a11y";
 import { localize, type TranslationKey } from "./localize";
 import { discoveryChangeMatters } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-UPDATES-CARD %c v${CARD_VERSION} `,
@@ -147,7 +148,7 @@ function updateName(attrs: Record<string, any>, id: string): string {
 }
 
 @customElement("m3-updates-card")
-export class M3UpdatesCard extends LitElement implements LovelaceCard {
+export class M3UpdatesCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3UpdatesCardConfig;

--- a/src/m3-waste-card.ts
+++ b/src/m3-waste-card.ts
@@ -28,6 +28,7 @@ import { shouldAnimate, isReducedMotion } from "./shared/animation";
 import { fireEvent } from "./shared/editor-helpers";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters, listEntities } from "./shared/should-update";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-WASTE-CARD %c v${CARD_VERSION} `,
@@ -51,7 +52,7 @@ interface WasteStream {
 }
 
 @customElement("m3-waste-card")
-export class M3WasteCard extends LitElement implements LovelaceCard {
+export class M3WasteCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3WasteCardConfig;

--- a/src/m3-weather-card.ts
+++ b/src/m3-weather-card.ts
@@ -46,6 +46,7 @@ import { fireEvent } from "./shared/editor-helpers";
 import { localize, type TranslationKey } from "./localize";
 import { hassChangeMatters } from "./shared/should-update";
 import { formatNumber } from "./shared/formatting";
+import { TemplatedCard } from "./shared/templated-card";
 
 console.info(
   `%c M3-WEATHER-CARD %c v${CARD_VERSION} `,
@@ -158,7 +159,7 @@ function smoothCurvePath(points: { x: number; y: number }[]): string {
 }
 
 @customElement("m3-weather-card")
-export class M3WeatherCard extends LitElement implements LovelaceCard {
+export class M3WeatherCard extends TemplatedCard(LitElement) implements LovelaceCard {
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: M3WeatherCardConfig;

--- a/src/shared/config-templates.test.ts
+++ b/src/shared/config-templates.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  applyConfigTemplates,
+  collectConfigTemplates,
+  ConfigTemplateResolver,
+} from "./config-templates";
+import type { HomeAssistant } from "../types";
+
+const identity = (template: string): string => template;
+
+describe("collectConfigTemplates", () => {
+  it("finds a template in a top-level field", () => {
+    expect(collectConfigTemplates({ type: "custom:m3-button-card", name: "{{ x }}" })).toEqual([
+      { path: ["name"], template: "{{ x }}" },
+    ]);
+  });
+
+  it("finds a statement block as well as an expression", () => {
+    const found = collectConfigTemplates({ name: "{% if true %}a{% endif %}" });
+    expect(found).toHaveLength(1);
+  });
+
+  it("ignores strings that are not templates", () => {
+    expect(collectConfigTemplates({ name: "Kitchen", entity: "light.kitchen" })).toEqual([]);
+  });
+
+  it("walks plain nested objects and arrays", () => {
+    expect(
+      collectConfigTemplates({
+        header: { title: "{{ a }}" },
+        buttons: [{ name: "{{ b }}" }, { name: "plain" }],
+        tags: ["{{ c }}", "plain"],
+      }),
+    ).toEqual([
+      { path: ["header", "title"], template: "{{ a }}" },
+      { path: ["buttons", 0, "name"], template: "{{ b }}" },
+      { path: ["tags", 0], template: "{{ c }}" },
+    ]);
+  });
+
+  it("does not descend into a nested object that carries its own type", () => {
+    // The popup holds a whole other card. Rendering its template here would
+    // bake the value it happens to have right now into a dead string, and the
+    // inner card — which renders templates live itself — would never update.
+    const found = collectConfigTemplates({
+      type: "custom:m3-room-card",
+      name: "{{ mine }}",
+      tap_action: {
+        action: "popup",
+        popup: {
+          content: {
+            type: "custom:mushroom-template-card",
+            primary: "{{ theirs }}",
+          },
+        },
+      },
+    });
+    expect(found).toEqual([{ path: ["name"], template: "{{ mine }}" }]);
+  });
+
+  it("does not descend into nested card configs in an array", () => {
+    const found = collectConfigTemplates({
+      type: "custom:m3-group-card",
+      title: "{{ mine }}",
+      cards: [
+        { type: "custom:mushroom-template-card", primary: "{{ theirs }}" },
+        { type: "custom:m3-button-card", name: "{{ also_theirs }}" },
+      ],
+    });
+    expect(found).toEqual([{ path: ["title"], template: "{{ mine }}" }]);
+  });
+
+  it("still walks the root config, whose own type is its own", () => {
+    const found = collectConfigTemplates({ type: "custom:m3-button-card", icon: "{{ i }}" });
+    expect(found).toEqual([{ path: ["icon"], template: "{{ i }}" }]);
+  });
+
+  it("descends into nested objects without a type", () => {
+    const found = collectConfigTemplates({
+      type: "custom:m3-nav-card",
+      badge: { text: "{{ n }}" },
+    });
+    expect(found).toEqual([{ path: ["badge", "text"], template: "{{ n }}" }]);
+  });
+
+  it("still walks a power-list entry, whose type names a consumer, not a card", () => {
+    const found = collectConfigTemplates({
+      type: "custom:m3-power-list-card",
+      entities: [{ entity: "sensor.washer", name: "{{ n }}", type: "producer" }],
+    });
+    expect(found).toEqual([{ path: ["entities", 0, "name"], template: "{{ n }}" }]);
+  });
+
+  it("ignores a non-string type, which is not a card config", () => {
+    const found = collectConfigTemplates({ thresholds: { type: 3, label: "{{ l }}" } });
+    expect(found).toEqual([{ path: ["thresholds", "label"], template: "{{ l }}" }]);
+  });
+
+  it("stops at a depth no real config reaches, so a cycle cannot hang the card", () => {
+    const cyclic: Record<string, unknown> = { name: "{{ a }}" };
+    cyclic.self = cyclic;
+    expect(() => collectConfigTemplates(cyclic)).not.toThrow();
+  });
+
+  it("returns nothing for a non-config value", () => {
+    expect(collectConfigTemplates(undefined)).toEqual([]);
+    expect(collectConfigTemplates("{{ a }}")).toEqual([]);
+  });
+});
+
+describe("applyConfigTemplates", () => {
+  it("substitutes every template, each with its own value", () => {
+    const config = {
+      type: "custom:m3-button-card",
+      name: "{{ a }}",
+      icon: "{{ b }}",
+      color: "{{ a }}",
+    };
+    const values: Record<string, string> = { "{{ a }}": "Kitchen", "{{ b }}": "mdi:lamp" };
+    const resolved = applyConfigTemplates(config, collectConfigTemplates(config), (t) => values[t]);
+
+    expect(resolved).toEqual({
+      type: "custom:m3-button-card",
+      name: "Kitchen",
+      icon: "mdi:lamp",
+      color: "Kitchen",
+    });
+  });
+
+  it("round-trips templates in arrays and nested objects by path", () => {
+    const config = {
+      buttons: [{ name: "{{ a }}" }, { name: "{{ b }}" }],
+      header: { title: "{{ c }}" },
+    };
+    const resolved = applyConfigTemplates(
+      config,
+      collectConfigTemplates(config),
+      (t) => `<${t.replace(/[{}% ]/g, "")}>`,
+    );
+
+    expect(resolved).toEqual({
+      buttons: [{ name: "<a>" }, { name: "<b>" }],
+      header: { title: "<c>" },
+    });
+  });
+
+  it("leaves the author's config untouched", () => {
+    const config = { name: "{{ a }}" };
+    const resolved = applyConfigTemplates(config, collectConfigTemplates(config), () => "Kitchen");
+
+    expect(config.name).toBe("{{ a }}");
+    expect(resolved).not.toBe(config);
+  });
+
+  it("keeps the identity of branches that hold no template", () => {
+    // The cards decide whether to rebuild their nested cards by comparing these
+    // by identity; a full clone would rebuild them on every pushed value.
+    const config = {
+      name: "{{ a }}",
+      cards: [{ type: "custom:m3-button-card", entity: "light.kitchen" }],
+    };
+    const resolved = applyConfigTemplates(config, collectConfigTemplates(config), () => "Kitchen");
+
+    expect(resolved.cards).toBe(config.cards);
+  });
+
+  it("returns the same object when there is nothing to substitute", () => {
+    const config = { name: "Kitchen" };
+    expect(applyConfigTemplates(config, collectConfigTemplates(config), identity)).toBe(config);
+  });
+
+  it("ignores a path the config no longer has", () => {
+    const resolved = applyConfigTemplates(
+      { name: "Kitchen" },
+      [{ path: ["header", "title"], template: "{{ a }}" }],
+      () => "x",
+    );
+    expect(resolved).toEqual({ name: "Kitchen" });
+  });
+});
+
+/**
+ * A hass with the one thing the resolver needs: a websocket that takes a
+ * `render_template` subscription. `push` plays the part of Home Assistant
+ * re-rendering a template because something it reads changed.
+ */
+function fakeHass(): {
+  hass: HomeAssistant;
+  templates: string[];
+  push(template: string, result: string): void;
+  stopped: string[];
+} {
+  const callbacks = new Map<string, (msg: { result?: unknown }) => void>();
+  const templates: string[] = [];
+  const stopped: string[] = [];
+
+  const hass = {
+    connection: {
+      subscribeMessage: (
+        cb: (msg: { result?: unknown }) => void,
+        payload: { type: string; template: string },
+      ) => {
+        expect(payload.type).toBe("render_template");
+        templates.push(payload.template);
+        callbacks.set(payload.template, cb);
+        return Promise.resolve(() => {
+          stopped.push(payload.template);
+          callbacks.delete(payload.template);
+        });
+      },
+    },
+  } as unknown as HomeAssistant;
+
+  return {
+    hass,
+    templates,
+    stopped,
+    push: (template, result) => callbacks.get(template)?.({ result }),
+  };
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("ConfigTemplateResolver", () => {
+  it("hands back the very same config, and opens nothing, when there are no templates", () => {
+    const ha = fakeHass();
+    const onChange = vi.fn();
+    const config = { type: "custom:m3-button-card", name: "Kitchen" };
+
+    const resolver = new ConfigTemplateResolver(onChange);
+    expect(resolver.sync(config, ha.hass)).toBe(config);
+    expect(resolver.sync(config, ha.hass)).toBe(config);
+
+    expect(ha.templates).toEqual([]);
+    expect(resolver.active).toBe(false);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("subscribes once per distinct template and substitutes what is pushed back", () => {
+    const ha = fakeHass();
+    const onChange = vi.fn();
+    const config = {
+      type: "custom:m3-button-card",
+      name: "{{ a }}",
+      icon: "{{ b }}",
+      // The same string twice is one subscription, not two.
+      color: "{{ a }}",
+    };
+
+    const resolver = new ConfigTemplateResolver(onChange);
+    resolver.sync(config, ha.hass);
+    expect(ha.templates).toEqual(["{{ a }}", "{{ b }}"]);
+
+    ha.push("{{ a }}", "Kitchen");
+    ha.push("{{ b }}", "mdi:lamp");
+    expect(onChange).toHaveBeenCalled();
+
+    expect(resolver.sync(config, ha.hass)).toEqual({
+      type: "custom:m3-button-card",
+      name: "Kitchen",
+      icon: "mdi:lamp",
+      color: "Kitchen",
+    });
+    expect(resolver.rawConfig).toBe(config);
+  });
+
+  it("recognises the config it handed back, and does not re-collect or re-subscribe", () => {
+    const ha = fakeHass();
+    const resolver = new ConfigTemplateResolver(() => {});
+    const config = { name: "{{ a }}" };
+
+    resolver.sync(config, ha.hass);
+    ha.push("{{ a }}", "Kitchen");
+    const resolved = resolver.sync(config, ha.hass);
+
+    // What the card now holds, fed back in on the next render.
+    expect(resolver.sync(resolved, ha.hass)).toBe(resolved);
+    expect(ha.templates).toEqual(["{{ a }}"]);
+    expect(resolver.rawConfig).toBe(config);
+  });
+
+  it("waits for a connection instead of subscribing against a hass that has none", () => {
+    const ha = fakeHass();
+    const resolver = new ConfigTemplateResolver(() => {});
+    const config = { name: "{{ a }}" };
+
+    resolver.sync(config, undefined);
+    resolver.sync(config, {} as HomeAssistant);
+    expect(ha.templates).toEqual([]);
+
+    resolver.sync(config, ha.hass);
+    expect(ha.templates).toEqual(["{{ a }}"]);
+  });
+
+  it("re-subscribes to what a new config asks for and drops the rest", async () => {
+    const ha = fakeHass();
+    const resolver = new ConfigTemplateResolver(() => {});
+
+    resolver.sync({ name: "{{ a }}" }, ha.hass);
+    resolver.sync({ name: "{{ b }}" }, ha.hass);
+    await flush();
+
+    expect(ha.templates).toEqual(["{{ a }}", "{{ b }}"]);
+    expect(ha.stopped).toEqual(["{{ a }}"]);
+  });
+
+  it("closes every subscription on close, and keeps the last resolved config", async () => {
+    const ha = fakeHass();
+    const resolver = new ConfigTemplateResolver(() => {});
+    const config = { name: "{{ a }}" };
+
+    resolver.sync(config, ha.hass);
+    ha.push("{{ a }}", "Kitchen");
+    const resolved = resolver.sync(config, ha.hass);
+    expect(resolved).toEqual({ name: "Kitchen" });
+
+    resolver.close();
+    await flush();
+    expect(ha.stopped).toEqual(["{{ a }}"]);
+
+    // Back from the view cache: the last known value is still on screen while
+    // the reopened subscription's first push is in flight.
+    expect(resolver.sync(resolved, ha.hass)).toBe(resolved);
+    expect(ha.templates).toEqual(["{{ a }}", "{{ a }}"]);
+  });
+
+  it("leaves a nested card's template for the nested card to render", () => {
+    const ha = fakeHass();
+    const resolver = new ConfigTemplateResolver(() => {});
+    const config = {
+      type: "custom:m3-room-card",
+      name: "{{ mine }}",
+      cards: [{ type: "custom:mushroom-template-card", primary: "{{ theirs }}" }],
+    };
+
+    resolver.sync(config, ha.hass);
+    expect(ha.templates).toEqual(["{{ mine }}"]);
+  });
+});

--- a/src/shared/config-templates.ts
+++ b/src/shared/config-templates.ts
@@ -1,0 +1,264 @@
+import { isTemplate, TemplateSubManager, type TemplateSubscription } from "./template-sub";
+import type { HomeAssistant } from "../types";
+
+// Finds the Jinja2 templates a card's author wrote into its *own* config, keeps
+// them subscribed, and puts the rendered values back in. No element in here —
+// `TemplatedCard` in templated-card.ts is the piece that hangs this off a card's
+// update cycle.
+//
+// THE NESTED-CARD RULE
+//
+// A card config is not a leaf. It can carry other cards inside it: `cards` on
+// the group and room cards, `content` under a popup action, mushroom chips or
+// badges someone dropped into a slot. Those configs belong to the inner card,
+// which is handed them verbatim and does its own thing with them — a mushroom
+// card, for one, renders templates itself, and it renders them *live*.
+//
+// Resolving them here would replace a live template with the one string it
+// happened to render to at the moment this card's config was walked, and the
+// inner card would then have nothing left to subscribe to: a badge that used to
+// follow a sensor would freeze at whatever it said when the view was opened.
+//
+// So the walk stops at any nested object that carries its own string `type`.
+// That is what a Lovelace card config looks like, whatever card it is for, and
+// it is the only marker available without a registry of every card in existence.
+// The root config's `type` is of course its own — the walk starts inside it.
+
+/** One templated string in a config, and where it sits. */
+export interface ConfigTemplateRef {
+  /** Object keys and array indices, from the root config down to the string. */
+  readonly path: readonly (string | number)[];
+  /** The Jinja2 source, verbatim — also the subscription's identity. */
+  readonly template: string;
+}
+
+// A config nested twelve levels deep is a config that has gone wrong, and the
+// limit is what keeps a hand-written cycle from walking forever.
+const MAX_DEPTH = 12;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * This project's own uses of `type` for something that is not a card: a
+ * power-list entity and a power-summary metric are each a `consumer` or a
+ * `producer` (`PowerEntryType` in types.ts). Without this the walk would take
+ * those entries for nested cards and skip the templates in their names.
+ *
+ * A new config field named `type` that is not a card type belongs in here.
+ */
+const NON_CARD_TYPES: ReadonlySet<string> = new Set(["consumer", "producer"]);
+
+/** A nested Lovelace card config: it has a `type`, so it is not ours to touch. */
+function isNestedCardConfig(value: unknown): boolean {
+  return isPlainObject(value) && typeof value.type === "string" && !NON_CARD_TYPES.has(value.type);
+}
+
+/**
+ * Every templated string the card owns, in walk order. Empty — the common case,
+ * since most dashboards use no templates at all — means there is nothing to
+ * subscribe to and nothing to substitute.
+ */
+export function collectConfigTemplates(config: unknown): ConfigTemplateRef[] {
+  const found: ConfigTemplateRef[] = [];
+  if (isPlainObject(config) || Array.isArray(config)) walk(config, [], found, 0);
+  return found;
+}
+
+function walk(
+  node: Record<string, unknown> | unknown[],
+  path: readonly (string | number)[],
+  found: ConfigTemplateRef[],
+  depth: number,
+): void {
+  if (depth > MAX_DEPTH) return;
+
+  const entries: [string | number, unknown][] = Array.isArray(node)
+    ? node.map((value, index) => [index, value])
+    : Object.entries(node);
+
+  for (const [key, value] of entries) {
+    if (typeof value === "string") {
+      if (isTemplate(value)) found.push({ path: [...path, key], template: value });
+      continue;
+    }
+    if (!isPlainObject(value) && !Array.isArray(value)) continue;
+    if (isNestedCardConfig(value)) continue; // see THE NESTED-CARD RULE above
+    walk(value, [...path, key], found, depth + 1);
+  }
+}
+
+/**
+ * The config as the author wrote it, with each collected template swapped for
+ * what `render` says it currently says.
+ *
+ * Copy-on-write along the paths that changed: a branch with no template under
+ * it comes back as the very same object. That matters beyond allocation — the
+ * cards compare `_config` sub-objects by identity to decide whether to rebuild
+ * their nested cards, so cloning the whole config on every pushed value would
+ * tear those down and rebuild them several times a minute.
+ */
+export function applyConfigTemplates<T>(
+  config: T,
+  refs: readonly ConfigTemplateRef[],
+  render: (template: string) => string,
+): T {
+  let resolved: unknown = config;
+  for (const ref of refs) {
+    resolved = replaceAt(resolved, ref.path, 0, render(ref.template));
+  }
+  return resolved as T;
+}
+
+function replaceAt(
+  node: unknown,
+  path: readonly (string | number)[],
+  index: number,
+  value: string,
+): unknown {
+  if (index >= path.length) return value;
+  const key = path[index];
+
+  if (Array.isArray(node) && typeof key === "number") {
+    const copy = node.slice();
+    copy[key] = replaceAt(node[key], path, index + 1, value);
+    return copy;
+  }
+  if (isPlainObject(node) && typeof key === "string") {
+    return { ...node, [key]: replaceAt(node[key], path, index + 1, value) };
+  }
+  // The config no longer has the shape the path was collected from. Nothing
+  // sensible to write, so the config is handed back untouched rather than
+  // grown a key nobody asked for.
+  return node;
+}
+
+/**
+ * Keeps one card's config resolved: collects the templates it holds, subscribes
+ * to them, and hands back the config with the current values substituted in.
+ *
+ * Element-free on purpose, like the subscription manager it sits on — a Lit
+ * element cannot be built in the Node environment the tests run in, and none of
+ * the bookkeeping here needs one. `TemplatedCard` in templated-card.ts is the
+ * thin piece that wires it to a card's update cycle.
+ */
+export class ConfigTemplateResolver {
+  private refs: readonly ConfigTemplateRef[] = [];
+  /** The config as the card's setConfig built it, templates unrendered. */
+  private raw?: unknown;
+  /** The resolved copy last handed back, so it is recognised when it returns. */
+  private resolved?: unknown;
+  private manager?: TemplateSubManager;
+  private subs?: Map<string, TemplateSubscription>;
+  /** A new config or a pushed value is waiting to be substituted in. */
+  private dirty = false;
+  /** The open subscriptions are out of step with the config's templates. */
+  private pending = false;
+
+  /** `onChange` is the card's requestUpdate — one call per pushed value. */
+  constructor(private readonly onChange: () => void) {}
+
+  /** True once a config with templates in it has been seen. */
+  public get active(): boolean {
+    return this.refs.length > 0;
+  }
+
+  /** The config as the author wrote it, templates unrendered. */
+  public get rawConfig(): unknown {
+    return this.raw;
+  }
+
+  /**
+   * The config the card should render. The very object it was passed when there
+   * is nothing to resolve — which is how a card that uses no templates pays
+   * nothing beyond the two identity checks at the top.
+   */
+  public sync(config: unknown, hass: HomeAssistant | undefined): unknown {
+    // Neither the config we were given nor the copy we handed back: the card's
+    // setConfig has run with something new.
+    if (config !== this.raw && config !== this.resolved) {
+      this.raw = config;
+      this.resolved = undefined;
+      this.refs = collectConfigTemplates(config);
+      this.dirty = this.refs.length > 0;
+      this.pending = this.refs.length > 0;
+      // Editing the last template out of a config closes its subscriptions.
+      if (!this.refs.length) this.close();
+    }
+
+    if (!this.refs.length) return config;
+
+    const manager = this.open(hass);
+    if (manager) {
+      // HA hands the card a new hass object on every state change; only the
+      // connection on it matters, and the subscriptions survive the swap.
+      manager.updateHass(hass);
+      if (this.pending) {
+        this.pending = false;
+        this.subscribe(manager);
+      }
+    }
+
+    if (this.dirty) {
+      this.dirty = false;
+      const subs = this.subs;
+      this.resolved = applyConfigTemplates(
+        this.raw,
+        this.refs,
+        // A template that has not been rendered yet reads empty, the same as it
+        // does on the nav card: the card draws its "no value" state for the few
+        // milliseconds before the first push, rather than the Jinja source.
+        (template) => subs?.get(template)?.value ?? "",
+      );
+    }
+    return this.resolved ?? config;
+  }
+
+  /**
+   * Drops every subscription. The last resolved config is kept, so a card put
+   * away in Home Assistant's view cache and brought back shows its last known
+   * values instead of blanking while the first push is in flight.
+   */
+  public close(): void {
+    this.subs?.clear();
+    this.manager?.disconnect();
+    this.manager = undefined;
+    this.pending = this.refs.length > 0;
+  }
+
+  private open(hass: HomeAssistant | undefined): TemplateSubManager | undefined {
+    if (this.manager) return this.manager;
+    // Before the websocket is on the object there is nothing to subscribe
+    // through, and a manager built now would hold a connection-less hass.
+    if (!(hass as unknown as { connection?: unknown } | undefined)?.connection) return undefined;
+    this.manager = new TemplateSubManager(hass, () => {
+      this.dirty = true;
+      this.onChange();
+    });
+    this.pending = true;
+    return this.manager;
+  }
+
+  /**
+   * One subscription per distinct template, and none for the ones the config no
+   * longer names. Runs on a config change, not on a render: a card re-renders
+   * on every state tick in the system, and re-subscribing there would tear down
+   * and rebuild the subscriptions several times a second.
+   */
+  private subscribe(manager: TemplateSubManager): void {
+    const subs = (this.subs ??= new Map<string, TemplateSubscription>());
+    const wanted = new Set(this.refs.map((ref) => ref.template));
+
+    for (const [template, sub] of subs) {
+      if (wanted.has(template)) continue;
+      sub.unsubscribe();
+      subs.delete(template);
+    }
+    for (const template of wanted) {
+      // The manager de-duplicates, so the same string behind two fields costs
+      // one subscription.
+      if (!subs.has(template)) subs.set(template, manager.subscribe(template));
+    }
+  }
+}

--- a/src/shared/templated-card.test.ts
+++ b/src/shared/templated-card.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import type { LitElement, PropertyValues } from "lit";
+import { TemplatedCard } from "./templated-card";
+
+// A stand-in for a card. These suites run in Vitest's Node environment, where
+// there is no DOM to define a custom element in, and the mixin needs none of
+// one: it hooks `willUpdate`, `connectedCallback` and `disconnectedCallback`,
+// which are called here by hand in the order Lit calls them.
+class FakeCard {
+  /** Counts the renders the mixin asks for. */
+  public updates = 0;
+  public connectedCallback(): void {}
+  public disconnectedCallback(): void {}
+  protected willUpdate(_changed: PropertyValues): void {}
+  public requestUpdate(): void {
+    this.updates++;
+  }
+}
+
+interface CardUnderTest {
+  _config?: unknown;
+  hass?: unknown;
+  updates: number;
+  rawConfig: unknown;
+  willUpdate(changed: PropertyValues): void;
+  connectedCallback(): void;
+  disconnectedCallback(): void;
+}
+
+function build(): {
+  card: CardUnderTest;
+  hass: unknown;
+  open: Map<string, (msg: { result?: unknown }) => void>;
+} {
+  const open = new Map<string, (msg: { result?: unknown }) => void>();
+  const hass = {
+    connection: {
+      subscribeMessage: (
+        cb: (msg: { result?: unknown }) => void,
+        payload: { template: string },
+      ) => {
+        open.set(payload.template, cb);
+        return Promise.resolve(() => open.delete(payload.template));
+      },
+    },
+  };
+  const Card = TemplatedCard(FakeCard as unknown as new () => LitElement);
+  return { card: new Card() as unknown as CardUnderTest, hass, open };
+}
+
+const flush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("TemplatedCard", () => {
+  it("leaves the config of a card that uses no templates exactly as it was", () => {
+    const { card, hass } = build();
+    const config = { type: "custom:m3-button-card", name: "Kitchen" };
+
+    card._config = config;
+    card.hass = hass;
+    card.willUpdate(new Map());
+    card.willUpdate(new Map());
+
+    // Same object, not a copy of it: nothing was walked, cloned or subscribed.
+    expect(card._config).toBe(config);
+  });
+
+  it("renders the card's templates and keeps the config steady in between", async () => {
+    const { card, hass, open } = build();
+    const authored = { type: "custom:m3-button-card", name: "{{ a }}", entity: "light.kitchen" };
+
+    card._config = { ...authored };
+    card.hass = hass;
+    card.willUpdate(new Map());
+    expect(open.size).toBe(1);
+
+    open.get("{{ a }}")!({ result: "Kitchen" });
+    expect(card.updates).toBeGreaterThan(0);
+
+    card.willUpdate(new Map());
+    expect(card._config).toEqual({
+      type: "custom:m3-button-card",
+      name: "Kitchen",
+      entity: "light.kitchen",
+    });
+    // The author's config is kept as written, templates and all.
+    expect(card.rawConfig).toEqual(authored);
+
+    // Nothing new pushed: the same object comes back, so a card that rebuilds
+    // on a config change does not rebuild on every render.
+    const resolved = card._config;
+    card.willUpdate(new Map());
+    expect(card._config).toBe(resolved);
+
+    // Home Assistant caches view elements: closed on the way out, reopened on
+    // the way back, and the last known values stay on screen throughout.
+    card.disconnectedCallback();
+    await flush();
+    expect(open.size).toBe(0);
+    expect(card._config).toBe(resolved);
+
+    card.connectedCallback();
+    card.willUpdate(new Map());
+    expect(open.size).toBe(1);
+    expect(card._config).toBe(resolved);
+  });
+
+  it("waits for the websocket rather than subscribing without one", () => {
+    const { card, hass, open } = build();
+
+    card._config = { name: "{{ a }}" };
+    card.hass = undefined;
+    card.willUpdate(new Map());
+    expect(open.size).toBe(0);
+
+    card.hass = hass;
+    card.willUpdate(new Map());
+    expect(open.size).toBe(1);
+  });
+});

--- a/src/shared/templated-card.ts
+++ b/src/shared/templated-card.ts
@@ -1,0 +1,101 @@
+import type { LitElement, PropertyValues } from "lit";
+import { ConfigTemplateResolver } from "./config-templates";
+import type { HomeAssistant } from "../types";
+
+// Jinja2 in a card's own config, for every card at once.
+//
+// A card binds its name, icon or colour to an entity's state, and that is all it
+// can do: "Kitchen", or the raw value — never "Kitchen · 21.4 °C", and never an
+// icon that depends on two entities at once. Mushroom's template card can do
+// that, so a dashboard moved over from mushroom loses it, and the workaround is
+// a template-sensor helper in the Home Assistant config for every card that
+// needs one.
+//
+// A card mixed with this gets it without knowing. Any string in its config
+// containing `{{` or `{%` is subscribed over Home Assistant's `render_template`
+// websocket subscription — the same live subscription the nav card already uses
+// for its entries — and substituted before the card renders. Which strings
+// those are is up to whoever wrote the dashboard: the mixin has no list of
+// fields, so anything a card reads out of its config can be templated.
+//
+// HOW IT ATTACHES
+//
+// Not by wrapping `setConfig`. Every card does real work in there — building
+// nested cards, pulling the entity registry over the websocket, reading
+// collapse state — and running all of it again just to get a new string in
+// would make a templated name cost as much as a dashboard reload. So the mixin
+// hooks `willUpdate`, which runs before every render, and swaps `_config` for a
+// resolved copy at that point. setConfig runs once per config, as before; a
+// pushed value costs one substitution and one render.
+//
+// Cards need no change of their own beyond mixing this in: they go on reading
+// `this._config`, which is now the config they were given with the templates
+// already rendered.
+//
+// A card whose config holds no template pays one small object per instance and
+// two identity comparisons per update, and nothing else: no subscription, no
+// manager, no copy of the config, no extra render. Its `_config` stays the very
+// object its own setConfig built.
+
+// The `any[]` rest parameter is what TypeScript requires of a mixin's base
+// constructor; nothing here reads the arguments.
+type Constructor<T> = new (...args: any[]) => T;
+
+/**
+ * The two members the mixin reaches for on the card.
+ *
+ * Both are declared by the cards themselves — `_config` as a private `@state()`
+ * and `hass` as a plain property on most cards but as an accessor pair on a
+ * couple of them — and re-declaring either here would clash with those
+ * declarations rather than unify with them. One cast, in one place, is the
+ * honest way to state what the mixin expects of its host: the config in
+ * `_config`, Home Assistant in `hass`.
+ */
+interface TemplatedCardHost {
+  _config?: unknown;
+  hass?: HomeAssistant;
+}
+
+export interface TemplatedCardMixin {
+  /** The config as the author wrote it, templates unrendered. */
+  readonly rawConfig: unknown;
+}
+
+export const TemplatedCard = <T extends Constructor<LitElement>>(
+  Base: T,
+): T & Constructor<TemplatedCardMixin> =>
+  class TemplatedCardElement extends Base {
+    private readonly _templates = new ConfigTemplateResolver(() => this.requestUpdate());
+
+    public get rawConfig(): unknown {
+      return this._templates.rawConfig;
+    }
+
+    public connectedCallback(): void {
+      super.connectedCallback();
+      // Home Assistant keeps view elements in a cache and re-inserts the same
+      // card when you navigate back, and a reconnect changes no property — so
+      // without this nothing would ask for the update that reopens the
+      // subscriptions closed on the way out.
+      if (this._templates.active) this.requestUpdate();
+    }
+
+    public disconnectedCallback(): void {
+      this._templates.close();
+      super.disconnectedCallback();
+    }
+
+    protected willUpdate(changed: PropertyValues): void {
+      super.willUpdate(changed);
+
+      const host = this as unknown as TemplatedCardHost;
+      const resolved = this._templates.sync(host._config, host.hass);
+      if (resolved === host._config) return;
+
+      // Written straight to the card's reactive `_config`. Inside willUpdate
+      // that folds into the render already in flight rather than scheduling a
+      // second one, and the card reads its resolved config without knowing any
+      // of this happened.
+      host._config = resolved;
+    }
+  };

--- a/src/types.ts
+++ b/src/types.ts
@@ -424,6 +424,9 @@ export interface M3CounterCardConfig {
   card_version?: string;
 }
 
+// One of the two places this project uses `type` for something that is not a
+// card type. `NON_CARD_TYPES` in shared/config-templates.ts lists these so the
+// template walk does not mistake such an entry for a nested card config.
 export type PowerEntryType = "consumer" | "producer";
 
 export interface PowerListEntity {


### PR DESCRIPTION
## Summary

Every card can now take Jinja2 in **its own string fields** — name, icon, colour, unit, whatever that card reads out of its config.

**The problem.** A field can be a fixed string or one entity's raw state, and nothing else. So a composed label — `"{{ states('sensor.kitchen_temperature') | round(1) }} °C"` — means creating a template-sensor helper in `configuration.yaml` for every card that wants one, and an icon that depends on an entity cannot be expressed at all. For anyone moving a dashboard over from mushroom (whose template card does this natively) every templated label, icon and colour is lost in the migration, and the workaround is one helper entity per card.

**The change.** A config string containing `{{` or `{%` is subscribed over Home Assistant's `render_template` websocket and substituted before the card renders. Values are pushed, not polled — this is the same live subscription `m3-nav-card` already uses for its entries, and it reuses `shared/template-sub.ts` unchanged, so a string used by two fields still costs one subscription.

```yaml
# before — a helper entity per card, and this one still could not be expressed
template:
  - sensor:
      - name: Kitchen label
        state: "{{ states('sensor.kitchen_temperature') | round(1) }} °C"
```

```yaml
# after
type: custom:m3-button-card
entity: light.kitchen
name: "{{ states('sensor.kitchen_temperature') | round(1) }} °C"
icon: >-
  {{ 'mdi:lightbulb-on' if is_state('light.kitchen', 'on') else 'mdi:lightbulb' }}
```

## Approach

Two new modules in `src/shared/`, and a one-line change to each card's class declaration:

- **`config-templates.ts`** — walks a config for templated strings, substitutes rendered values back in copy-on-write, and holds `ConfigTemplateResolver`, the per-card bookkeeping (collect → subscribe → substitute). Element-free, so it is unit-testable in the Node environment the existing suites run in.
- **`templated-card.ts`** — `TemplatedCard(LitElement)`, a Lit mixin that wires that resolver to a card's update cycle (`willUpdate` / `connectedCallback` / `disconnectedCallback`).
- Each card: `extends LitElement implements LovelaceCard` → `extends TemplatedCard(LitElement) implements LovelaceCard`, plus the import. **Nothing else changes in any card** — no per-card field lists, no changed render paths. 37 card files; `m3-system-card` inherits it from `m3-nas-card`, so all 38 cards are covered.

**Why a mixin on `willUpdate` and not a `setConfig` wrapper.** Every card does real work in `setConfig` — building nested cards, pulling the entity registry over the websocket, reading collapse state. Re-running that to get a new string in would make a templated name cost as much as a dashboard reload every time the value changed. The mixin instead swaps `_config` for a resolved copy in `willUpdate`, which runs before the render that needs it and folds into the update already in flight. `setConfig` still runs exactly once per config; a pushed value costs one substitution and one render. The card keeps reading `this._config`, which now arrives resolved, and the config as the author wrote it stays available as `rawConfig`.

The one thing the mixin knows about its host is the house convention — config in `_config`, Home Assistant in `hass`. Both are declared by the cards themselves (and `hass` differently on different cards: property on most, accessor pair on the room and nav cards), so re-declaring either in the mixin would clash rather than unify; it reaches them through a single documented cast, in one place.

**Nested card configs are deliberately not descended into.** A card config can carry other cards: `cards:` on the group and room cards, a popup action's content, a mushroom card in a slot. Those belong to the inner card, which renders its own templates — and renders them *live*. Resolving one here would hand that card the single string it happened to render to at the moment the outer card was configured; the field would freeze there and never follow its sensor again. So the walk stops at any nested object carrying its own string `type`, which is what a card config looks like whatever card it is for. The root config's own `type` is excluded from the rule, and so are this project's own non-card `type` values (`consumer` / `producer` on power-list entities and power-summary metrics — `NON_CARD_TYPES`, with a pointer left next to `PowerEntryType` in `types.ts`).

**Backwards compatible and free when unused.** A card whose config holds no template is not walked, subscribes to nothing, and its `_config` stays the very object its own `setConfig` built — no copy, no extra render. Cost is one small object per card instance and two identity comparisons per update. Nothing about existing configs changes. `m3-nav-card` keeps its own per-entry template handling, including the boolean `hidden` / `disabled` semantics, and is not mixed in — its fields are already covered and doing both would double the subscriptions.

## Affected card(s)

Shared (`src/shared/*`) plus the class declaration of all 37 card files (`m3-system-card` inherits from the NAS card). `m3-nav-card` intentionally unchanged.

## Tests

`npm run lint`, `npm test` (93 passing, 21 of them new) and `npm run build` all pass, as does `npm run test:contrast`.

New tests in `src/shared/config-templates.test.ts` and `src/shared/templated-card.test.ts` cover, among others:

- a nested object carrying its own `type` is **not** descended into — both under a popup action and inside a `cards:` array
- several templates round-trip through collect → subscribe → substitute, by path, including duplicates sharing one subscription
- branches with no template keep their object identity (so cards do not rebuild their nested cards on every pushed value)
- a card with no templates gets back the very object it passed in, and opens no subscription
- subscriptions close on disconnect, reopen on reconnect, and the last resolved values stay on screen in between

## Testing note

This design is running in a production Home Assistant install as an external monkey-patch over the released bundle — same detection, same subscription, same nested-card rule — and has behaved correctly there, including leaving a nested `mushroom-template-card` inside a popup untouched. **This native version has not been on-device tested**, only type-checked, unit-tested and built; it deserves a smoke test in a real dashboard before merge. `docs/TESTING.md` has three new cross-cutting rows (C16–C18) for exactly that: a templated field following its sensor, a nested card still rendering its own template, and a card without templates opening no `render_template` at all.

## On the shape of it

This is an architectural change rather than a small fix, and it touches every card's class declaration, so please redirect it if you would rather have it shaped differently — a base class instead of a mixin, an opt-in per card, a fixed list of templatable fields per card instead of "any string in the config", or template support declared explicitly in each card's config schema. The walker, the resolver and the docs would carry over largely unchanged; only the attachment point would move. Happy to rework, split it up, or drop the parts you do not want.

## Checklist

- [x] `npm run lint` passes (typecheck)
- [x] `npm run build` passes
- [ ] Tested manually in a real Home Assistant dashboard (see `docs/TESTING.md`) — validated in production via an equivalent external implementation; this native version wants a maintainer smoke test
- [x] `prefers-reduced-motion` respected for any new animation (no new animation)
- [x] README.md / README.de.md updated if config options changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XA73RX69Vc6o5eRu9uHuH
