### PR TITLE
Add M3 Search Card: a Material 3 search bar for the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,41 @@ Versionierung folgt [SemVer](https://semver.org/lang/de/).
   source: synology_dsm
   mount_names:
     volume_1: Media
+- **A new card: M3 Search Card** (`custom:m3-search-card`). A Material 3 search
+  bar that sits on the dashboard itself and opens Home Assistant's own quick
+  bar — the entity search by default, the command palette with
+  `mode: command` — plus an optional trailing Assist button. It reads no
+  entity and needs no configuration at all: `type: custom:m3-search-card` is a
+  working card.
+
+  The gap it fills is that Home Assistant's only search entry point is in the
+  header, and the header's search button is not rendered at all on a narrow
+  screen. On a phone or a wall tablet there is no way to reach the entity
+  search from a dashboard except by keyboard, which those devices do not have.
+  The header's Assist button goes the same way, which is why this card can
+  carry one.
+
+  It opens the dialog by replaying Home Assistant's own keyboard shortcut
+  rather than by firing `show-dialog`, and that is not a shortcut of its own
+  taking: `ha-quick-bar` is code-split out of the frontend's main bundle, and
+  the only thing that pulls it in is the frontend's own caller, which hands the
+  dialog manager an `import()` callback alongside the tag. A card loaded as its
+  own Lovelace resource cannot name that module path, so a bare `show-dialog`
+  lands on a custom element that was never defined and fails with "Unknown
+  dialog type loaded". Replaying the key hands the lazy import back to the
+  handler that owns it, and leaves the card depending on a shortcut that is
+  user-visible and listed in Home Assistant's own `Shift+?` dialog rather than
+  on an internal module path.
+
+  Everything that can take those shortcuts away is checked rather than assumed,
+  because a control that silently does nothing is worse than one that is not
+  drawn: the per-user "keyboard shortcuts" profile switch (the bar dims and
+  says so), the `conversation` integration Assist needs (no integration, no
+  Assist button), and the fact that the command palette is registered for
+  admins only (a non-admin gets the entity search, which is at least a search).
+
+  ```yaml
+  type: custom:m3-search-card
   ```
 
 ### Changed
@@ -333,6 +368,43 @@ Versionierung folgt [SemVer](https://semver.org/lang/de/).
   source: synology_dsm
   mount_names:
     volume_1: Medien
+- **Eine neue Karte: M3 Search Card** (`custom:m3-search-card`). Eine
+  Material-3-Suchleiste, die auf dem Dashboard selbst sitzt und Home Assistants
+  eigene Schnellsuche öffnet — standardmäßig die Entitätssuche, mit
+  `mode: command` die Befehlssuche — dazu optional ein Assist-Knopf am rechten
+  Rand. Sie liest keine Entität und braucht überhaupt keine Konfiguration:
+  `type: custom:m3-search-card` ist bereits eine funktionierende Karte.
+
+  Die Lücke, die sie füllt: Home Assistants einziger Einstieg in die Suche
+  sitzt in der Kopfzeile, und der Such-Knopf dort wird auf schmalen
+  Bildschirmen gar nicht gezeichnet. Auf einem Telefon oder einem Wandtablet
+  führt vom Dashboard aus also kein Weg zur Entitätssuche außer über eine
+  Tastatur, die diese Geräte nicht haben. Dem Assist-Knopf der Kopfzeile geht
+  es genauso — deshalb kann diese Karte einen mitbringen.
+
+  Sie öffnet den Dialog, indem sie Home Assistants eigenes Tastenkürzel
+  nachspielt, statt `show-dialog` zu feuern, und das ist keine selbstgewählte
+  Abkürzung: `ha-quick-bar` liegt in einem eigenen Chunk außerhalb des
+  Hauptbundles, und hereingeholt wird es einzig vom Aufrufer des Frontends
+  selbst, der dem Dialog-Manager neben dem Tag auch einen `import()`-Callback
+  mitgibt. Eine als eigene Lovelace-Ressource geladene Karte kann diesen
+  Modulpfad nicht benennen; ein bloßes `show-dialog` landet deshalb auf einem
+  nie definierten Custom Element und scheitert mit „Unknown dialog type
+  loaded". Das Nachspielen der Taste gibt den Nachlade-Import an den Handler
+  zurück, dem er gehört, und lässt die Karte an einem Tastenkürzel hängen, das
+  sichtbar und in HAs eigenem `Shift+?`-Dialog aufgeführt ist, statt an einem
+  internen Modulpfad.
+
+  Alles, was diese Kürzel wegnehmen kann, wird geprüft statt angenommen, denn
+  ein Bedienelement, das stillschweigend nichts tut, ist schlimmer als eines,
+  das gar nicht da ist: der Profil-Schalter „Tastenkürzel" (die Leiste wird
+  blass und sagt es), die von Assist benötigte Integration `conversation`
+  (ohne sie kein Assist-Knopf) und der Umstand, dass die Befehlssuche nur für
+  Administratoren registriert ist (ohne Admin-Rechte kommt die Entitätssuche —
+  immerhin eine Suche).
+
+  ```yaml
+  type: custom:m3-search-card
   ```
 
 ### Geändert

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ card links to its full documentation further down.
 | [Status](#m3-status-card) | `m3-status-card` | Big numbers, text and yes/no states, with a rule list behind them |
 | [Heading](#m3-heading-card) | `m3-heading-card` | Section headings between the cards: simple, with status, a divider, or collapsible |
 | [Nav](#m3-nav-card) | `m3-nav-card` | A navigation bar for the dashboard, in five variants, with a pull-up drawer |
+| [Search](#m3-search-card) | `m3-search-card` | A Material 3 search bar that opens Home Assistant's own search and Assist |
 | [Group](#m3-group-card) | `m3-group-card` | Several cards on one shared surface, so they read as a single block |
 | [Room](#m3-room-card) | `m3-room-card` | One card per area: every device type it finds, climate readings and presence |
 | [Humidifier](#m3-humidifier-card) | `m3-humidifier-card` | Target humidity, mode, fan speed and extras — and it need not be a humidifier entity |
@@ -4203,6 +4204,103 @@ cards:
 | `corners` | object | – | Optional per-corner override, same as every other card |
 | `glass_background` | boolean | `true` | Frosted glass background |
 | `card_background` | string | – | Override background color |
+
+</details>
+
+## M3 Search Card
+
+A Material 3 search bar on the dashboard itself. It looks like the M3 search
+bar in its resting state — a 56px pill, a leading search icon, placeholder
+text, an optional trailing Assist button — and a tap opens Home Assistant's
+own quick bar, the same dialog the `E` key opens.
+
+It exists because Home Assistant's own search entry point is in the header,
+and the header's search button is **not rendered at all on a narrow screen**.
+On a phone or a wall tablet there is no way to reach the entity search from a
+dashboard except by keyboard, which those devices do not have. The same is
+true of the header's Assist button, which is why this card can carry one.
+
+Nothing is configured to make it work: the card reads no entity and needs no
+setup.
+
+<details>
+<summary>Configuration, examples & options</summary>
+
+```yaml
+type: custom:m3-search-card
+```
+
+A bar that opens the command palette instead, with its own text and no Assist
+button:
+
+```yaml
+type: custom:m3-search-card
+mode: command
+placeholder: Run a command
+icon: mdi:console
+show_assist: false
+accent_color: primary
+radius: 28
+```
+
+Or one that ignores the search entirely and navigates somewhere — `tap_action`
+replaces the built-in behaviour rather than running alongside it:
+
+```yaml
+type: custom:m3-search-card
+placeholder: Everything in the house
+icon: mdi:home-search
+tap_action:
+  action: navigate
+  navigation_path: /lovelace/all
+```
+
+### How it opens the dialog
+
+`ha-quick-bar` is code-split out of the frontend's main bundle, and the only
+thing that pulls it in is Home Assistant's own caller, which passes the dialog
+manager an `import()` callback alongside the dialog tag. A card loaded as its
+own Lovelace resource cannot name that module path, so firing a bare
+`show-dialog` event lands on a custom element that was never defined and fails
+with *"Unknown dialog type loaded"*.
+
+So the card asks for the dialog the way a keyboard does: it dispatches the
+`keydown` Home Assistant already listens for, and the frontend's own handler
+does the lazy import and opens what it built. That makes the card depend on
+the shortcut — user-visible, listed in Home Assistant's own `Shift+?` dialog —
+instead of on an internal module path.
+
+Three things can take those shortcuts away, and the card checks all three
+rather than drawing a control that silently does nothing:
+
+- **Keyboard shortcuts** can be switched off per user under *Profile →
+  Keyboard shortcuts*. The bar dims and says so.
+- **The command palette (`C`) is registered for admins only.** On a non-admin
+  account `mode: command` opens the entity search instead, which is at least a
+  search; the editor says so too.
+- **Assist needs the `conversation` integration.** It is part of
+  `default_config`, so it is normally there — where it is not, the trailing
+  button is left out.
+
+### Configuration options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `placeholder` | string | `Search Home Assistant`, or `Run a command` in command mode | The resting text in the bar |
+| `label` | string | – | Alias for `placeholder`, for consistency with the cards that call their one piece of text a label. `placeholder` wins if both are set |
+| `icon` | string | `mdi:magnify` | Leading icon |
+| `mode` | `entity` \| `command` | `entity` | Which quick bar a tap opens. `command` needs an admin account |
+| `show_assist` | boolean | `true` | Trailing Assist button. Drawn only when Assist is actually reachable |
+| `assist_icon` | string | `mdi:microphone` | Icon on the Assist button |
+| `tap_action` | Action | – | Standard Home Assistant action config. Once set it **replaces** opening the search |
+| `accent_color` | string | – (neutral, as M3's own search bar is) | Colors the leading icon and the Assist button's well |
+| `text_color` | string | – | Override text color |
+| `secondary_text_color` | string | – | Override the placeholder color |
+| `card_background` | string | – | Override background color |
+| `radius` | number (px) | `28` | Card corner radius — 28 is half of the 56px bar, i.e. a full pill |
+| `corners` | object | – | Optional per-corner override, same as every other card |
+| `glass_background` | boolean | `true` | Frosted glass background |
+| `animation` | `auto` \| `on` \| `off` | `auto` | The press feedback (a corner-radius morph); `auto` respects `prefers-reduced-motion` |
 
 </details>
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,7 +54,7 @@ Beide Fehler ließen die Seite besser aussehen, als sie war.
 - Ein Handy oder ein per DevTools emuliertes Touch-Gerät für alle Drag-Interaktionen
   (Wave-Slider, Wischen) — Maus-Events allein decken `touch-action`-Konflikte nicht ab.
 
-## Cross-Cutting-Checkliste (für jede der 39 Karten)
+## Cross-Cutting-Checkliste (für jede der 40 Karten)
 
 Diese Punkte gelten kartenübergreifend, weil sie über gemeinsame `shared/*`-Module
 implementiert sind. Ein Fehlschlag hier betrifft potenziell alle Karten gleichzeitig.
@@ -697,6 +697,27 @@ einer entscheidet, was ein Raum **zeigt**, der andere, was ein Tippen
 | Kaputte Kindkarte | Eine Karte mit ungültigem `type` eintragen | HA's eigene Fehlerkarte erscheint an ihrer Stelle; die übrigen Karten rendern weiter |
 | Leere Gruppe | `cards: []` | Karte rendert leer statt zu werfen |
 
+## M3 Search Card
+
+Die Karte ruft Dialoge des Frontends über dessen eigene Tastenkürzel auf.
+Alles Interessante steckt darin, ob dieser Weg noch trägt — Testen also bitte
+in der aktuellen HA-Version und mindestens einmal auf einem echten Telefon.
+
+| Test | Schritte | Erwartung |
+|---|---|---|
+| Minimalkonfiguration | Nur `type: custom:m3-search-card` | Pille mit Lupe, Platzhaltertext und Assist-Knopf; ein Tipp öffnet die Entitätssuche |
+| Befehlsmodus | `mode: command` als Administrator | Die Befehls-Schnellsuche öffnet sich, nicht die Entitätssuche |
+| Ohne Admin-Rechte | `mode: command` mit einem Nicht-Admin-Konto | Ein Tipp öffnet die Entitätssuche statt gar nichts zu tun; der Editor weist darauf hin |
+| Tastenkürzel aus | Profil → Tastenkürzel abschalten, Dashboard neu laden | Leiste ist blass, `aria-disabled="true"`, Tooltip erklärt es; kein Tipp öffnet etwas |
+| Assist fehlt | Instanz ohne `conversation` | Kein Assist-Knopf — statt eines Knopfes, der nichts tut |
+| Assist | Assist-Knopf antippen | Der Sprachdialog öffnet sich, nicht die Suche |
+| Schmaler Bildschirm | Auf dem Telefon, wo die Kopfzeile keinen Such-Knopf zeichnet | Die Karte ist der einzige Weg zur Suche und funktioniert |
+| Tastatur | Mit Tab auf die Leiste, dann Enter, dann Leertaste | Beide öffnen den Dialog; der Fokusring ist sichtbar; der Assist-Knopf ist ein eigenes Tab-Ziel |
+| Tap-Aktion | `tap_action: {action: navigate, ...}` setzen | Es wird navigiert; die Suche öffnet **nicht** zusätzlich |
+| Markierter Text | Text auf der Seite markieren, dann die Leiste antippen | Der Dialog öffnet trotzdem — die Auswahl wird vorher aufgehoben, sonst blockiert das Frontend jedes Kürzel |
+| Druck-Feedback | Finger auf der Leiste halten | Die Ecken ziehen sich zusammen und federn zurück; mit `animation: off` und bei reduzierter Bewegung passiert nichts |
+| Kontrast | In hellem und dunklem Theme, mit und ohne `accent_color` | Platzhalter und Icons bleiben lesbar |
+
 ## M3 Nav Card
 
 Die Karte ist Navigations-Chrome statt Datenkachel: sie positioniert sich gegen
@@ -788,7 +809,7 @@ kleiner konfigurierte Kachel angehoben und nicht abgeschnitten wird.
 1. Alle Cross-Cutting-Punkte (C1–C15) auf mindestens 3 unterschiedlichen Karten
    durchgehen (eine einfache, eine mit Editor-Unterinhalten wie Battery/Power-List,
    eine mit Animation wie Progress/Light).
-2. Jede der 39 Karten mindestens einmal mit einer Minimal-Config und einmal mit
+2. Jede der 40 Karten mindestens einmal mit einer Minimal-Config und einmal mit
    einer voll ausgereizten Config (alle Farben/Optionen gesetzt) rendern.
 3. `CHANGELOG.md` gegen die tatsächlich getesteten Änderungen abgleichen.
 4. Die Kartenzahl an allen fünf Stellen abgleichen, an denen sie steht: beide

--- a/src/const.ts
+++ b/src/const.ts
@@ -1996,3 +1996,26 @@ export const APPLIANCE_NARROW_PX = HUMIDIFIER_NARROW_PX;
 
 /** Colours handed to option pills and buttons that configure none. */
 export const APPLIANCE_PALETTE = HUMIDIFIER_MODE_PALETTE;
+// ---- Search -----------------------------------------------------------------
+// Measurements from the Material 3 search bar in its resting state: a 56px-tall
+// fully-rounded container, a 24px leading icon inset 16px from the edge, and
+// trailing icon buttons on a 40px target so their 24px glyph lands on the same
+// 16px inset at the other end. The pill shape falls out of the suite's own
+// scale rather than being asserted: half of 56 is 28, which is RADIUS.card.
+export const DEFAULT_SEARCH_RADIUS = RADIUS.card;
+export const SEARCH_BAR_HEIGHT = 56;
+export const SEARCH_ICON_SIZE = 24;
+export const SEARCH_ACTION_SIZE = 40;
+export const SEARCH_ACTION_RADIUS = SEARCH_ACTION_SIZE / 2;
+export const DEFAULT_SEARCH_ICON = "mdi:magnify";
+export const DEFAULT_SEARCH_ASSIST_ICON = "mdi:microphone";
+/** Well behind the trailing Assist button — the same weight as the heading
+ *  card's action button, which is the other "quiet button on a card" in the
+ *  suite. */
+export const SEARCH_ACTION_TINT = 8;
+/** The bar's own wash while a finger is down. Below the action tint, because
+ *  it covers the whole bar rather than a 40px button. */
+export const SEARCH_PRESSED_TINT = 6;
+/** How long the pressed wash stays after a tap that opens a dialog. The dialog
+ *  takes the focus, so without a timer the bar would stay lit behind it. */
+export const SEARCH_FEEDBACK_MS = 180;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,4 @@ export * from "./m3-lights-overview-card";
 export * from "./m3-chip-buttons-card";
 export * from "./m3-group-card";
 export * from "./m3-appliance-card";
+export * from "./m3-search-card";

--- a/src/localize.ts
+++ b/src/localize.ts
@@ -2043,6 +2043,30 @@ const translations = {
     editor_appliance_block_buttons: "Aktions-Buttons",
     editor_appliance_block_chips: "Status-Chips",
     editor_appliance_remove: "Entfernen",
+    search_placeholder: "Home Assistant durchsuchen",
+    search_placeholder_command: "Befehl ausführen",
+    search_assist_label: "Assist öffnen",
+    search_shortcuts_off: "Tastenkürzel sind im Profil deaktiviert — die Suche lässt sich so nicht öffnen.",
+    editor_search_placeholder: "Text in der Leiste",
+    editor_search_placeholder_hint:
+      "Leer lassen für den Standardtext, der zum gewählten Modus passt.",
+    editor_search_mode: "Was ein Tipp öffnet",
+    editor_search_mode_entity: "Entitäten durchsuchen (Taste E)",
+    editor_search_mode_command: "Befehle durchsuchen (Taste C)",
+    editor_search_mode_hint:
+      "Die Karte löst dasselbe Tastenkürzel aus, das Home Assistant selbst belegt — anders lässt sich der Dialog von außen nicht laden.",
+    editor_search_admin_warning:
+      "Die Befehlssuche registriert Home Assistant nur für Administratoren. Ohne Admin-Rechte öffnet ein Tipp stattdessen die Entitätssuche.",
+    editor_search_shortcuts_warning:
+      "In diesem Profil sind Tastenkürzel abgeschaltet (Profil → Tastenkürzel). Solange das so ist, kann die Karte keinen Suchdialog öffnen.",
+    editor_search_tap_action_hint:
+      "Eine gesetzte Tap-Aktion ersetzt das Öffnen der Suche vollständig.",
+    editor_search_assist: "Assist-Knopf",
+    editor_search_show_assist: "Assist-Knopf anzeigen",
+    editor_search_assist_icon: "Assist-Icon",
+    editor_search_assist_hint:
+      "Wird nur gezeichnet, wenn die Integration „conversation\" geladen und Tastenkürzel aktiv sind.",
+    editor_search_accent_color: "Akzentfarbe (Icon und Assist-Knopf)",
   },
   en: {
     off: "Off",
@@ -4082,6 +4106,28 @@ const translations = {
     editor_appliance_block_buttons: "Action buttons",
     editor_appliance_block_chips: "Status chips",
     editor_appliance_remove: "Remove",
+    search_placeholder: "Search Home Assistant",
+    search_placeholder_command: "Run a command",
+    search_assist_label: "Open Assist",
+    search_shortcuts_off: "Keyboard shortcuts are switched off in your profile, so the search cannot be opened.",
+    editor_search_placeholder: "Text in the bar",
+    editor_search_placeholder_hint: "Leave empty for the default text that matches the chosen mode.",
+    editor_search_mode: "What a tap opens",
+    editor_search_mode_entity: "Search entities (the E key)",
+    editor_search_mode_command: "Search commands (the C key)",
+    editor_search_mode_hint:
+      "The card replays the same keyboard shortcut Home Assistant binds itself — the dialog cannot be loaded from outside the frontend any other way.",
+    editor_search_admin_warning:
+      "Home Assistant registers the command search for admins only. Without admin rights a tap opens the entity search instead.",
+    editor_search_shortcuts_warning:
+      "Keyboard shortcuts are off in this profile (Profile → Keyboard shortcuts). While they are, the card cannot open a search dialog.",
+    editor_search_tap_action_hint: "A tap action, once set, replaces opening the search entirely.",
+    editor_search_assist: "Assist button",
+    editor_search_show_assist: "Show the Assist button",
+    editor_search_assist_icon: "Assist icon",
+    editor_search_assist_hint:
+      "Only drawn when the `conversation` integration is loaded and keyboard shortcuts are on.",
+    editor_search_accent_color: "Accent color (icon and Assist button)",
   },
 } as const;
 

--- a/src/m3-search-card-editor.ts
+++ b/src/m3-search-card-editor.ts
@@ -1,0 +1,292 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import type { HomeAssistant, LovelaceCardEditor, M3SearchCardConfig } from "./types";
+import { DEFAULT_SEARCH_ASSIST_ICON, DEFAULT_SEARCH_ICON, DEFAULT_SEARCH_RADIUS } from "./const";
+import { localize, type TranslationKey } from "./localize";
+import { colorRow, editorStyles, fireEvent, type SchemaEntry } from "./shared/editor-helpers";
+import { radiusLabelMap } from "./shared/radius-editor";
+import {
+  initAppearanceState,
+  radiusPresetPatch,
+  cornerPresetPatch,
+  renderAppearanceSection,
+  type AppearanceState,
+} from "./shared/appearance-editor";
+import { quickBarModeAvailable, shortcutsAvailable } from "./shared/quick-bar";
+
+@customElement("m3-search-card-editor")
+export class M3SearchCardEditor extends LitElement implements LovelaceCardEditor {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _config?: M3SearchCardConfig;
+  @state() private _appearance: AppearanceState = {
+    showCustomRadius: false,
+    showCorners: false,
+    cornerCustom: {},
+  };
+
+  public setConfig(config: M3SearchCardConfig): void {
+    this._config = config;
+    this._appearance = initAppearanceState(config, DEFAULT_SEARCH_RADIUS);
+  }
+
+  private get _language(): string {
+    return this.hass?.locale?.language ?? this.hass?.language ?? "en";
+  }
+
+  private _t(key: TranslationKey): string {
+    return localize(key, this._language);
+  }
+
+  private _emit(config: M3SearchCardConfig): void {
+    this._config = config;
+    fireEvent(this, "config-changed", { config });
+  }
+
+  private _contentSchema(): SchemaEntry[] {
+    return [
+      { name: "placeholder", selector: { text: {} } },
+      { name: "icon", selector: { icon: {} } },
+    ];
+  }
+
+  private _behaviorSchema(): SchemaEntry[] {
+    return [
+      {
+        name: "mode",
+        selector: {
+          select: {
+            mode: "dropdown",
+            options: [
+              { value: "entity", label: this._t("editor_search_mode_entity") },
+              { value: "command", label: this._t("editor_search_mode_command") },
+            ],
+          },
+        },
+      },
+      { name: "tap_action", selector: { ui_action: {} } },
+    ];
+  }
+
+  private _assistSchema(): SchemaEntry[] {
+    return [
+      { name: "show_assist", selector: { boolean: {} } },
+      { name: "assist_icon", selector: { icon: {} } },
+    ];
+  }
+
+  private _animationSchema(): SchemaEntry[] {
+    return [
+      {
+        name: "animation",
+        selector: {
+          select: {
+            mode: "dropdown",
+            options: [
+              { value: "auto", label: this._t("editor_progress_animation_auto") },
+              { value: "on", label: this._t("editor_progress_animation_on") },
+              { value: "off", label: this._t("editor_progress_animation_off") },
+            ],
+          },
+        },
+      },
+    ];
+  }
+
+  private _computeLabel = (schema: SchemaEntry): string => {
+    const labelMap: Record<string, TranslationKey> = {
+      placeholder: "editor_search_placeholder",
+      icon: "editor_icon",
+      mode: "editor_search_mode",
+      tap_action: "editor_tap_action",
+      show_assist: "editor_search_show_assist",
+      assist_icon: "editor_search_assist_icon",
+      animation: "editor_progress_animation",
+      glass_background: "editor_glass_background",
+      ...radiusLabelMap,
+    };
+    const key = labelMap[schema.name];
+    return key ? this._t(key) : schema.name;
+  };
+
+  private _valueChanged(ev: CustomEvent): void {
+    if (!this._config) return;
+    const next: Record<string, unknown> = {
+      ...this._config,
+      ...(ev.detail.value as Record<string, unknown>),
+    };
+    // An emptied text field means "use the default", not "show nothing".
+    for (const key of ["placeholder", "icon", "assist_icon"]) {
+      if (next[key] === "") delete next[key];
+    }
+    this._emit(next as unknown as M3SearchCardConfig);
+  }
+
+  private _colorChanged(
+    field: "accent_color" | "text_color" | "secondary_text_color" | "card_background",
+    value: string,
+  ): void {
+    if (!this._config) return;
+    if (value) {
+      this._emit({ ...this._config, [field]: value });
+    } else {
+      const { [field]: _removed, ...rest } = this._config;
+      this._emit(rest as M3SearchCardConfig);
+    }
+  }
+
+  private _radiusPresetChanged(ev: CustomEvent): void {
+    if (!this._config) return;
+    const patch = radiusPresetPatch(ev.detail.value.radius_preset as string);
+    this._appearance = { ...this._appearance, showCustomRadius: patch.showCustomRadius };
+    if (patch.radius !== undefined) this._emit({ ...this._config, radius: patch.radius });
+  }
+
+  private _cornersToggleChanged(ev: CustomEvent): void {
+    if (!this._config) return;
+    const showCorners = ev.detail.value.use_corners as boolean;
+    this._appearance = { ...this._appearance, showCorners };
+    if (!showCorners) {
+      const { corners: _removed, ...rest } = this._config;
+      this._emit(rest as M3SearchCardConfig);
+    }
+  }
+
+  private _cornerPresetChanged(key: string, ev: CustomEvent): void {
+    if (!this._config) return;
+    const patch = cornerPresetPatch(ev.detail.value[key] as string);
+    this._appearance = {
+      ...this._appearance,
+      cornerCustom: { ...this._appearance.cornerCustom, [key]: patch.custom },
+    };
+    if (patch.px !== undefined) {
+      this._emit({ ...this._config, corners: { ...(this._config.corners ?? {}), [key]: patch.px } });
+    }
+  }
+
+  private _cornerValueChanged(key: string, ev: CustomEvent): void {
+    if (!this._config) return;
+    const px = ev.detail.value[key] as number;
+    this._emit({ ...this._config, corners: { ...(this._config.corners ?? {}), [key]: px } });
+  }
+
+  protected render() {
+    if (!this.hass || !this._config) return nothing;
+    const cfg = this._config;
+
+    const contentData = { placeholder: cfg.placeholder ?? cfg.label ?? "", icon: cfg.icon ?? "" };
+    const behaviorData = { mode: cfg.mode ?? "entity", tap_action: cfg.tap_action };
+    const assistData = {
+      show_assist: cfg.show_assist ?? true,
+      assist_icon: cfg.assist_icon ?? DEFAULT_SEARCH_ASSIST_ICON,
+    };
+    const animationData = { animation: cfg.animation ?? "auto" };
+
+    return html`
+      <div class="editor">
+        <ha-expansion-panel outlined .header=${this._t("editor_content")} expanded>
+          <ha-icon slot="leading-icon" icon=${DEFAULT_SEARCH_ICON}></ha-icon>
+          <div class="panel-content">
+            <ha-form
+              .hass=${this.hass}
+              .data=${contentData}
+              .schema=${this._contentSchema()}
+              .computeLabel=${this._computeLabel}
+              @value-changed=${this._valueChanged}
+            ></ha-form>
+            <div class="hint">${this._t("editor_search_placeholder_hint")}</div>
+          </div>
+        </ha-expansion-panel>
+
+        <ha-expansion-panel outlined .header=${this._t("editor_behavior")} expanded>
+          <ha-icon slot="leading-icon" icon="mdi:gesture-tap-button"></ha-icon>
+          <div class="panel-content">
+            <ha-form
+              .hass=${this.hass}
+              .data=${behaviorData}
+              .schema=${this._behaviorSchema()}
+              .computeLabel=${this._computeLabel}
+              @value-changed=${this._valueChanged}
+            ></ha-form>
+            <div class="hint">${this._t("editor_search_mode_hint")}</div>
+            ${cfg.mode === "command" && !quickBarModeAvailable(this.hass, "command")
+              ? html`<div class="hint warn">${this._t("editor_search_admin_warning")}</div>`
+              : nothing}
+            ${shortcutsAvailable(this.hass)
+              ? nothing
+              : html`<div class="hint warn">${this._t("editor_search_shortcuts_warning")}</div>`}
+            <div class="hint">${this._t("editor_search_tap_action_hint")}</div>
+          </div>
+        </ha-expansion-panel>
+
+        <ha-expansion-panel outlined .header=${this._t("editor_search_assist")}>
+          <ha-icon slot="leading-icon" icon=${DEFAULT_SEARCH_ASSIST_ICON}></ha-icon>
+          <div class="panel-content">
+            <ha-form
+              .hass=${this.hass}
+              .data=${assistData}
+              .schema=${this._assistSchema()}
+              .computeLabel=${this._computeLabel}
+              @value-changed=${this._valueChanged}
+            ></ha-form>
+            <div class="hint">${this._t("editor_search_assist_hint")}</div>
+          </div>
+        </ha-expansion-panel>
+
+        <ha-expansion-panel outlined .header=${this._t("editor_progress_colors")}>
+          <ha-icon slot="leading-icon" icon="mdi:palette-outline"></ha-icon>
+          <div class="panel-content">
+            ${colorRow(this._t("editor_search_accent_color"), cfg.accent_color, (v) =>
+              this._colorChanged("accent_color", v),
+            )}
+            ${colorRow(this._t("editor_progress_text_color"), cfg.text_color, (v) =>
+              this._colorChanged("text_color", v),
+            )}
+            ${colorRow(this._t("editor_progress_secondary_text_color"), cfg.secondary_text_color, (v) =>
+              this._colorChanged("secondary_text_color", v),
+            )}
+            ${colorRow(this._t("editor_progress_card_background"), cfg.card_background, (v) =>
+              this._colorChanged("card_background", v),
+            )}
+          </div>
+        </ha-expansion-panel>
+
+        <ha-expansion-panel outlined .header=${this._t("editor_progress_animation")}>
+          <ha-icon slot="leading-icon" icon="mdi:wave"></ha-icon>
+          <div class="panel-content">
+            <ha-form
+              .hass=${this.hass}
+              .data=${animationData}
+              .schema=${this._animationSchema()}
+              .computeLabel=${this._computeLabel}
+              @value-changed=${this._valueChanged}
+            ></ha-form>
+            <div class="hint">${this._t("editor_progress_animation_reduced_motion_hint")}</div>
+          </div>
+        </ha-expansion-panel>
+
+        ${renderAppearanceSection({
+          hass: this.hass,
+          language: this._language,
+          config: this._config,
+          defaultRadius: DEFAULT_SEARCH_RADIUS,
+          state: this._appearance,
+          computeLabel: this._computeLabel,
+          onValueChanged: this._valueChanged.bind(this),
+          onRadiusPresetChanged: this._radiusPresetChanged.bind(this),
+          onCornersToggleChanged: this._cornersToggleChanged.bind(this),
+          onCornerPresetChanged: this._cornerPresetChanged.bind(this),
+          onCornerValueChanged: this._cornerValueChanged.bind(this),
+        })}
+      </div>
+    `;
+  }
+
+  static styles = editorStyles;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "m3-search-card-editor": M3SearchCardEditor;
+  }
+}

--- a/src/m3-search-card.ts
+++ b/src/m3-search-card.ts
@@ -1,0 +1,382 @@
+import { LitElement, html, css, nothing, unsafeCSS } from "lit";
+import type { TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import type {
+  CornerRadiusConfig,
+  HomeAssistant,
+  LovelaceCard,
+  LovelaceCardEditor,
+  LovelaceGridOptions,
+  M3SearchCardConfig,
+} from "./types";
+import {
+  CARD_VERSION,
+  DEFAULT_SEARCH_ASSIST_ICON,
+  DEFAULT_SEARCH_ICON,
+  DEFAULT_SEARCH_RADIUS,
+  SEARCH_ACTION_RADIUS,
+  SEARCH_ACTION_SIZE,
+  SEARCH_ACTION_TINT,
+  SEARCH_BAR_HEIGHT,
+  SEARCH_FEEDBACK_MS,
+  SEARCH_ICON_SIZE,
+  resolveCornerRadius,
+} from "./const";
+import { localize, type TranslationKey } from "./localize";
+import { STANDARD_EASING, shouldAnimate } from "./shared/animation";
+import { activateOnKey } from "./shared/a11y";
+import { handleAction, isActionable } from "./shared/actions";
+import {
+  buildCssVars,
+  foregroundColor,
+  foregroundOn,
+  resolveCommonColors,
+  resolveThemeColor,
+  tintOn,
+} from "./shared/color-config";
+import { glassCardClass, glassCardStyles } from "./shared/glass-card";
+import { assistAvailable, openAssist, openQuickBar, shortcutsAvailable } from "./shared/quick-bar";
+import { TemplatedCard } from "./shared/templated-card";
+
+const EASING = unsafeCSS(STANDARD_EASING);
+
+console.info(
+  `%c M3-SEARCH-CARD %c v${CARD_VERSION} `,
+  "color: #222; background: #85b7eb; font-weight: 700; border-radius: 4px 0 0 4px;",
+  "color: #85b7eb; background: #222; font-weight: 700; border-radius: 0 4px 4px 0;",
+);
+
+/**
+ * How far the corners travel while the bar is held.
+ *
+ * The suite's press feedback is a radius morph rather than a ripple, and 0.4 is
+ * what the list rows already use — 18px resting, 11px pressed. Applying it as a
+ * factor rather than as a fixed target keeps the morph proportional for someone
+ * who has set a squarer `radius`, and keeps a per-corner shape recognisably the
+ * shape they configured.
+ */
+const PRESSED_RADIUS_FACTOR = 0.4;
+
+function pressCorners(corners: CornerRadiusConfig | undefined): CornerRadiusConfig | undefined {
+  if (!corners) return undefined;
+  const out: CornerRadiusConfig = {};
+  for (const [key, value] of Object.entries(corners)) {
+    if (typeof value === "number") {
+      out[key as keyof CornerRadiusConfig] = Math.round(value * PRESSED_RADIUS_FACTOR);
+    }
+  }
+  return out;
+}
+
+@customElement("m3-search-card")
+export class M3SearchCard extends TemplatedCard(LitElement) implements LovelaceCard {
+  @property({ attribute: false }) public hass?: HomeAssistant;
+
+  @state() private _config?: M3SearchCardConfig;
+  @state() private _pressed = false;
+
+  private _pressTimer?: number;
+
+  public static async getConfigElement(): Promise<LovelaceCardEditor> {
+    await import("./m3-search-card-editor");
+    return document.createElement("m3-search-card-editor") as unknown as LovelaceCardEditor;
+  }
+
+  public static getStubConfig(): M3SearchCardConfig {
+    return { type: "custom:m3-search-card" };
+  }
+
+  // Nothing here reads an entity, so there is no config to validate beyond the
+  // defaults every card fills in.
+  public setConfig(config: M3SearchCardConfig): void {
+    this._config = { glass_background: true, animation: "auto", ...config };
+  }
+
+  public getCardSize(): number {
+    return 1;
+  }
+
+  public getGridOptions(): LovelaceGridOptions {
+    // Full width by default, because that is the shape a search bar has and
+    // where a dashboard expects to find one — but resizable down to half a
+    // section, since a bar beside a heading is a reasonable thing to want.
+    return { columns: "full", rows: "auto", min_columns: 6, min_rows: 1 };
+  }
+
+  public disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.clearTimeout(this._pressTimer);
+  }
+
+  // No shouldUpdate override: this card reads no entity state at all, so
+  // hassChangeMatters would have an empty list to filter on. What it does read
+  // off `hass` — the language, the admin flag, the loaded components, the
+  // shortcuts preference — changes about as often as the page reloads.
+
+  private get _language(): string {
+    return this.hass?.locale?.language ?? this.hass?.language ?? "en";
+  }
+
+  private _t(key: TranslationKey): string {
+    return localize(key, this._language);
+  }
+
+  private get _text(): string {
+    const cfg = this._config;
+    return (
+      cfg?.placeholder ??
+      cfg?.label ??
+      this._t(cfg?.mode === "command" ? "search_placeholder_command" : "search_placeholder")
+    );
+  }
+
+  private get _showAssist(): boolean {
+    // Default on: Assist ships in `default_config`, and the header's own Assist
+    // button disappears on a narrow screen for the same reason its search
+    // button does — which is the gap this card exists to fill. Where Assist is
+    // genuinely absent, or the profile has turned keyboard shortcuts off, the
+    // button is dropped rather than drawn as a control that does nothing.
+    if (this._config?.show_assist === false) return false;
+    return assistAvailable(this.hass);
+  }
+
+  // ---- interaction ---------------------------------------------------------
+
+  private _flashPress(): void {
+    if (!shouldAnimate(this._config?.animation)) return;
+    this._pressed = true;
+    window.clearTimeout(this._pressTimer);
+    this._pressTimer = window.setTimeout(() => {
+      this._pressed = false;
+    }, SEARCH_FEEDBACK_MS);
+  }
+
+  private _onPressStart = (): void => {
+    if (!shouldAnimate(this._config?.animation)) return;
+    window.clearTimeout(this._pressTimer);
+    this._pressed = true;
+  };
+
+  private _onPressEnd = (): void => {
+    window.clearTimeout(this._pressTimer);
+    this._pressed = false;
+  };
+
+  private _onSearch = (e: Event): void => {
+    e.stopPropagation();
+    this._flashPress();
+    const action = this._config?.tap_action;
+    // A configured action replaces the built-in behaviour rather than running
+    // beside it: two dialogs on one tap is not a thing anyone configures for.
+    if (action) {
+      if (isActionable(action)) handleAction(this, this.hass, action);
+      return;
+    }
+    openQuickBar(this.hass, this._config?.mode);
+  };
+
+  private _onAssist = (e: Event): void => {
+    e.stopPropagation();
+    openAssist();
+  };
+
+  // ---- rendering -----------------------------------------------------------
+
+  private _renderAssist(accentCss: string): TemplateResult | typeof nothing {
+    if (!this._showAssist) return nothing;
+    const background = tintOn(this, accentCss, undefined, SEARCH_ACTION_TINT);
+    const label = this._t("search_assist_label");
+    return html`
+      <button
+        class="assist"
+        style=${`background: ${background}; color: ${foregroundOn(accentCss, background, 3, this)};`}
+        title=${label}
+        aria-label=${label}
+        @click=${this._onAssist}
+      >
+        <ha-icon icon=${this._config?.assist_icon ?? DEFAULT_SEARCH_ASSIST_ICON}></ha-icon>
+      </button>
+    `;
+  }
+
+  protected render(): TemplateResult | typeof nothing {
+    const cfg = this._config;
+    if (!cfg || !this.hass) return nothing;
+
+    const base = cfg.radius ?? DEFAULT_SEARCH_RADIUS;
+    const radius = resolveCornerRadius(base, cfg.corners);
+    const pressedRadius = resolveCornerRadius(
+      Math.round(base * PRESSED_RADIUS_FACTOR),
+      pressCorners(cfg.corners),
+    );
+    const shape = this._pressed ? pressedRadius : radius;
+
+    const { textColorCss, secondaryTextColorCss, cardBackgroundCss } = resolveCommonColors(cfg);
+    // Unset means the Material default — a neutral bar, where the leading icon
+    // and the placeholder are both on-surface-variant — rather than a house
+    // colour this card would be inventing for a control that is meant to look
+    // like part of the frontend.
+    const accentCss = cfg.accent_color
+      ? resolveThemeColor(cfg.accent_color)
+      : secondaryTextColorCss;
+
+    const cssVars = buildCssVars({
+      "m3s-text": textColorCss,
+      "m3s-secondary": secondaryTextColorCss,
+      "m3s-icon": cfg.accent_color ? foregroundColor(this, accentCss, 3) : secondaryTextColorCss,
+    });
+
+    // Whether the tap can actually do anything. Without the shortcuts there is
+    // no dialog to open, so the bar says so instead of pretending: a configured
+    // tap_action still works, because it goes nowhere near them.
+    const usable = !!cfg.tap_action || shortcutsAvailable(this.hass);
+    const label = this._text;
+
+    return html`
+      <ha-card style=${`border-radius: ${shape};`}>
+        <div
+          class="card-inner ${glassCardClass(cfg.glass_background)} ${shouldAnimate(cfg.animation)
+            ? ""
+            : "no-animations"}"
+          style=${`border-radius: ${shape}; ${cssVars}${
+            cardBackgroundCss ? ` background: ${cardBackgroundCss};` : ""
+          }`}
+        >
+          <div
+            class="bar ${usable ? "" : "disabled"}"
+            role="button"
+            tabindex="0"
+            aria-label=${label}
+            aria-haspopup="dialog"
+            aria-disabled=${usable ? "false" : "true"}
+            title=${usable ? label : this._t("search_shortcuts_off")}
+            @click=${this._onSearch}
+            @keydown=${activateOnKey(this._onSearch)}
+            @pointerdown=${this._onPressStart}
+            @pointerup=${this._onPressEnd}
+            @pointercancel=${this._onPressEnd}
+            @pointerleave=${this._onPressEnd}
+          >
+            <ha-icon class="leading" icon=${cfg.icon ?? DEFAULT_SEARCH_ICON}></ha-icon>
+            <span class="placeholder">${label}</span>
+          </div>
+          ${this._renderAssist(accentCss)}
+        </div>
+      </ha-card>
+    `;
+  }
+
+  static styles = [
+    glassCardStyles,
+    css`
+      ha-card {
+        transition: border-radius ${unsafeCSS(SEARCH_FEEDBACK_MS)}ms ${EASING};
+      }
+
+      .card-inner {
+        flex-direction: row;
+        align-items: center;
+        gap: 4px;
+        /* 16px to the leading glyph and 16px to the trailing one, which is the
+           M3 search bar's inset at both ends — the trailing button carries 8px
+           of its own inside a 40px target, so its padding is 8. */
+        padding: 0 8px 0 16px;
+        min-height: ${SEARCH_BAR_HEIGHT}px;
+        transition: border-radius ${unsafeCSS(SEARCH_FEEDBACK_MS)}ms ${EASING};
+      }
+
+      .bar {
+        flex: 1;
+        min-width: 0;
+        align-self: stretch;
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        cursor: pointer;
+      }
+
+      /* Still focusable and still announced — it is only the dialog behind it
+         that is out of reach, and the title says why. */
+      .bar.disabled {
+        cursor: default;
+        opacity: 0.55;
+      }
+
+      .bar:focus-visible {
+        outline: 2px solid var(--m3s-text, var(--primary-text-color));
+        outline-offset: -2px;
+        border-radius: 8px;
+      }
+
+      .leading {
+        flex-shrink: 0;
+        color: var(--m3s-icon, var(--primary-text-color));
+        --mdc-icon-size: ${SEARCH_ICON_SIZE}px;
+      }
+
+      .placeholder {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        /* M3 body-large, the search bar's own type role. */
+        font-size: 16px;
+        line-height: 24px;
+        color: var(--m3s-secondary, var(--primary-text-color));
+        /* 0.7 rather than the 0.6 a small muted label in this suite uses: this
+           is 16px regular text, so it owes 4.5:1, and 0.6 does not clear that
+           against a light card. */
+        opacity: 0.7;
+      }
+
+      .assist {
+        flex-shrink: 0;
+        width: ${SEARCH_ACTION_SIZE}px;
+        height: ${SEARCH_ACTION_SIZE}px;
+        border: none;
+        border-radius: ${SEARCH_ACTION_RADIUS}px;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        font-family: inherit;
+        --mdc-icon-size: ${SEARCH_ICON_SIZE}px;
+        transition: border-radius ${unsafeCSS(SEARCH_FEEDBACK_MS)}ms ${EASING};
+      }
+
+      .assist:active {
+        border-radius: ${Math.round(SEARCH_ACTION_RADIUS * PRESSED_RADIUS_FACTOR)}px;
+      }
+
+      .assist:focus-visible {
+        outline: 2px solid var(--m3s-text, var(--primary-text-color));
+        outline-offset: 2px;
+      }
+
+      .no-animations,
+      .no-animations .assist {
+        transition: none;
+      }
+    `,
+  ];
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "m3-search-card": M3SearchCard;
+  }
+}
+
+const windowWithCards = window as unknown as {
+  customCards: Array<Record<string, unknown>>;
+};
+windowWithCards.customCards = windowWithCards.customCards || [];
+windowWithCards.customCards.push({
+  type: "m3-search-card",
+  name: "M3 Search Card",
+  description:
+    "A Material 3 search bar on the dashboard itself, opening Home Assistant's own entity or command search — and Assist. The header's search button is not drawn on a narrow screen; this is.",
+  preview: true,
+  documentationURL: "https://github.com/j0sp0r/m3-cards",
+});

--- a/src/shared/quick-bar.test.ts
+++ b/src/shared/quick-bar.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  ASSIST_SHORTCUT,
+  assistAvailable,
+  quickBarModeAvailable,
+  quickBarShortcut,
+  shortcutEventInit,
+  shortcutsAvailable,
+} from "./quick-bar";
+import type { HomeAssistant } from "../types";
+
+function fakeHass(overrides: Partial<HomeAssistant> = {}): HomeAssistant {
+  return {
+    config: { unit_system: { temperature: "°C" }, components: ["conversation"] },
+    user: { is_admin: true },
+    enableShortcuts: true,
+    ...overrides,
+  } as unknown as HomeAssistant;
+}
+
+describe("shortcutEventInit", () => {
+  it("sets both key and code", () => {
+    // Not redundant: Home Assistant registers each shortcut twice, once per
+    // field, and tinykeys drops any event missing either one.
+    const init = shortcutEventInit(quickBarShortcut(fakeHass(), "entity"));
+    expect(init.key).toBe("e");
+    expect(init.code).toBe("KeyE");
+  });
+
+  it("mirrors keyCode into which, for older frontends", () => {
+    const init = shortcutEventInit(ASSIST_SHORTCUT);
+    expect(init.keyCode).toBe(65);
+    expect(init.which).toBe(65);
+  });
+
+  it("is composed, so it escapes the card's shadow root", () => {
+    expect(shortcutEventInit(ASSIST_SHORTCUT).composed).toBe(true);
+  });
+
+  it("carries no modifier, which would disqualify the press", () => {
+    const init = shortcutEventInit(ASSIST_SHORTCUT) as unknown as Record<string, unknown>;
+    for (const flag of ["ctrlKey", "metaKey", "altKey", "shiftKey", "repeat"]) {
+      expect(init[flag]).toBeUndefined();
+    }
+  });
+});
+
+describe("quickBarShortcut", () => {
+  it("sends e for the entity quick bar", () => {
+    expect(quickBarShortcut(fakeHass(), "entity").key).toBe("e");
+  });
+
+  it("sends c for the command quick bar, for an admin", () => {
+    expect(quickBarShortcut(fakeHass(), "command").key).toBe("c");
+  });
+
+  it("falls back to the entity search for a non-admin, since c reaches nothing", () => {
+    const hass = fakeHass({ user: { is_admin: false } } as Partial<HomeAssistant>);
+    expect(quickBarShortcut(hass, "command").key).toBe("e");
+  });
+
+  it("defaults to the entity search for an unset or unknown mode", () => {
+    expect(quickBarShortcut(fakeHass(), undefined).key).toBe("e");
+    expect(quickBarShortcut(fakeHass(), "nonsense" as never).key).toBe("e");
+  });
+});
+
+describe("availability", () => {
+  it("treats an unstated enableShortcuts as on, not off", () => {
+    expect(shortcutsAvailable({} as HomeAssistant)).toBe(true);
+    expect(shortcutsAvailable(undefined)).toBe(true);
+  });
+
+  it("respects an explicit enableShortcuts: false", () => {
+    expect(shortcutsAvailable(fakeHass({ enableShortcuts: false }))).toBe(false);
+    expect(assistAvailable(fakeHass({ enableShortcuts: false }))).toBe(false);
+    expect(quickBarModeAvailable(fakeHass({ enableShortcuts: false }), "entity")).toBe(false);
+  });
+
+  it("needs the conversation component for Assist", () => {
+    const without = fakeHass({
+      config: { unit_system: { temperature: "°C" }, components: ["light"] },
+    } as Partial<HomeAssistant>);
+    expect(assistAvailable(without)).toBe(false);
+    expect(assistAvailable(fakeHass())).toBe(true);
+  });
+
+  it("treats a missing component list as no evidence either way", () => {
+    const noList = fakeHass({
+      config: { unit_system: { temperature: "°C" } },
+    } as Partial<HomeAssistant>);
+    expect(assistAvailable(noList)).toBe(true);
+  });
+
+  it("treats a missing user as no evidence that command mode is out of reach", () => {
+    const noUser = fakeHass({ user: undefined });
+    expect(quickBarModeAvailable(noUser, "command")).toBe(true);
+  });
+});

--- a/src/shared/quick-bar.ts
+++ b/src/shared/quick-bar.ts
@@ -1,0 +1,181 @@
+import type { HomeAssistant } from "../types";
+
+// Opening Home Assistant's own quick bar (its entity/command search dialog)
+// and its Assist dialog from a card.
+//
+// WHY THIS IS NOT A `show-dialog` EVENT
+//
+// Every other dialog this suite opens goes the obvious way: dispatch
+// `show-dialog` with a `dialogTag` and let the frontend show it. That does not
+// work for the quick bar. `ha-quick-bar` is code-split out of the frontend's
+// main bundle, and the only thing that pulls it in is the frontend's own
+// caller, which hands the dialog manager an import callback alongside the tag:
+//
+//   fireEvent(element, "show-dialog", {
+//     dialogTag: "ha-quick-bar",
+//     dialogImport: () => import("./ha-quick-bar"),
+//     dialogParams,
+//   });                    // frontend: dialogs/quick-bar/show-dialog-quick-bar.ts
+//
+// A card cannot supply that callback: the specifier is a path inside the
+// frontend bundle, which a Lovelace resource loaded as its own module has no
+// way to name. Firing the event without it makes the dialog manager
+// `createElement("ha-quick-bar")` on a tag that was never defined, so it gets a
+// plain HTMLElement with no `showDialog` on it and throws
+// "Unknown dialog type loaded" (frontend: dialogs/make-dialog-manager.ts).
+//
+// So the card asks for the dialog the way a keyboard does — it replays the
+// shortcut, and the frontend's own handler does the lazy import and opens what
+// it built. The card then depends on the shortcut rather than on the dialog's
+// tag and module path: a user-visible, documented contract, listed in Home
+// Assistant's own Shift+? shortcut dialog, instead of an internal one.
+//
+// WHAT THE HANDLER ACTUALLY CHECKS
+//
+// Verified against home-assistant/frontend `dev` (2026-09), where the old
+// hand-rolled keydown listener has been replaced by tinykeys:
+// `src/state/quick-bar-mixin.ts` registers the bindings, and
+// `src/common/keyboard/shortcuts.ts` wraps them. What that means for a
+// synthetic event:
+//
+//   * The listener is on `window`, keydown, bubble phase, and `isTrusted` is
+//     never consulted — a dispatched KeyboardEvent is accepted.
+//   * tinykeys drops anything that is not `event.key && event.code &&
+//     event.getModifierState`, so BOTH `key` and `code` have to be set. This is
+//     the detail that silently breaks a hand-written attempt: an event built
+//     with `{ key: "e" }` alone never matches. `keyCode`/`which` are set here
+//     too — the current frontend does not read them, older ones did, and they
+//     cost nothing.
+//   * `repeat`, `isComposing` and any modifier flag disqualify the press.
+//   * A non-empty `window.getSelection()` blocks every binding except Ctrl/⌘+K,
+//     which is why the selection is collapsed before dispatching.
+//
+// WHAT CAN LEGITIMATELY TAKE THE SHORTCUTS AWAY
+//
+// Three things, all checked rather than assumed, because a control that
+// silently does nothing is worse than one that is not drawn:
+//
+//   * "Keyboard shortcuts" is a per-user profile switch, and every handler
+//     returns immediately when `hass.enableShortcuts` is off.
+//   * The command palette (`c`) is registered only for admins, so on a
+//     non-admin account that key reaches nothing at all.
+//   * Assist needs the `conversation` integration loaded. It is part of
+//     `default_config`, so it is there on a normal install, but a hand-written
+//     configuration.yaml can leave it out.
+
+/** Which of the quick bar's two modes a tap should open. */
+export type QuickBarMode = "entity" | "command";
+
+/** Everything needed to reconstruct a key press the frontend will recognise. */
+export interface ShortcutKey {
+  key: string;
+  code: string;
+  keyCode: number;
+}
+
+// The frontend registers each of these twice — once by `key` for latin
+// keyboards and once by `code` for the rest — so setting both is not belt and
+// braces, it is how either registration can match.
+export const QUICK_BAR_SHORTCUTS: Record<QuickBarMode, ShortcutKey> = {
+  entity: { key: "e", code: "KeyE", keyCode: 69 },
+  command: { key: "c", code: "KeyC", keyCode: 67 },
+};
+
+export const ASSIST_SHORTCUT: ShortcutKey = { key: "a", code: "KeyA", keyCode: 65 };
+
+/** Whether this account can reach a given mode's shortcut at all. */
+export function quickBarModeAvailable(
+  hass: HomeAssistant | undefined,
+  mode: QuickBarMode | undefined,
+): boolean {
+  if (!shortcutsAvailable(hass)) return false;
+  if (mode !== "command") return true;
+  // Not a permission we are inventing: the frontend registers `c` and `d`
+  // inside `if (this.hass?.user?.is_admin)`, and its own dialog strips a
+  // `command` mode back to the unscoped search for a non-admin.
+  return hass?.user?.is_admin !== false;
+}
+
+/**
+ * The key to send for a mode, degrading rather than doing nothing.
+ *
+ * A non-admin asking for the command palette gets the entity search instead. It
+ * is not what the config said, but `c` reaches no handler on that account, so
+ * the alternative is a search bar that does not search — and the two dialogs
+ * are close enough that landing in the wrong one is self-explanatory, while
+ * landing nowhere is not.
+ */
+export function quickBarShortcut(
+  hass: HomeAssistant | undefined,
+  mode: QuickBarMode | undefined,
+): ShortcutKey {
+  const wanted = QUICK_BAR_SHORTCUTS[mode as QuickBarMode] ?? QUICK_BAR_SHORTCUTS.entity;
+  if (wanted === QUICK_BAR_SHORTCUTS.command && !quickBarModeAvailable(hass, "command")) {
+    return QUICK_BAR_SHORTCUTS.entity;
+  }
+  return wanted;
+}
+
+/**
+ * The KeyboardEvent init for one shortcut.
+ *
+ * Pure, and deliberately separate from the dispatch below: this project's test
+ * suite has no DOM, so a helper that constructed the event could not be tested
+ * at all, while the shape it would have built can be asserted here.
+ *
+ * `composed` is set because the card lives in a shadow root — an event that
+ * does not cross the boundary never reaches a `window` listener — and every
+ * modifier is left off because tinykeys refuses a press carrying one.
+ */
+export function shortcutEventInit(
+  shortcut: ShortcutKey,
+): KeyboardEventInit & { keyCode: number; which: number } {
+  return {
+    key: shortcut.key,
+    code: shortcut.code,
+    keyCode: shortcut.keyCode,
+    which: shortcut.keyCode,
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  };
+}
+
+/** Replays one shortcut for Home Assistant's global handler to pick up. */
+export function replayShortcut(shortcut: ShortcutKey): void {
+  // Every binding but Ctrl/⌘+K is skipped while anything on the page is
+  // selected. A tap normally collapses the selection on its own, but a tap that
+  // followed a drag over some text does not, and the bar would then appear to
+  // be dead for no reason the user can see.
+  const selection = window.getSelection?.();
+  if (selection?.toString()) selection.removeAllRanges();
+  window.dispatchEvent(new KeyboardEvent("keydown", shortcutEventInit(shortcut)));
+}
+
+/**
+ * Whether replaying a shortcut can do anything at all.
+ *
+ * Only an explicit `false` counts as off: an older frontend does not expose the
+ * flag, and reading "not stated" as "disabled" would hide the card's whole
+ * point on an install where the shortcut works perfectly well.
+ */
+export function shortcutsAvailable(hass: HomeAssistant | undefined): boolean {
+  return hass?.enableShortcuts !== false;
+}
+
+/** Whether Assist exists to be opened, on top of the shortcut being live. */
+export function assistAvailable(hass: HomeAssistant | undefined): boolean {
+  if (!shortcutsAvailable(hass)) return false;
+  const components = hass?.config?.components;
+  // Same rule again — a frontend that hands over no component list is not
+  // evidence that Assist is missing.
+  return !components || components.includes("conversation");
+}
+
+export function openQuickBar(hass: HomeAssistant | undefined, mode: QuickBarMode | undefined): void {
+  replayShortcut(quickBarShortcut(hass, mode));
+}
+
+export function openAssist(): void {
+  replayShortcut(ASSIST_SHORTCUT);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { NotifyConfigBase } from "./shared/notify-editor";
 import type { EntityFilterConfig } from "./shared/entity-filter";
 import type { LightGroupHandling } from "./shared/ha-registry";
+import type { QuickBarMode } from "./shared/quick-bar";
 
 export interface HomeAssistant {
   states: Record<string, HassEntity>;
@@ -24,7 +25,19 @@ export interface HomeAssistant {
     };
     /** IANA zone the Home Assistant instance runs in, e.g. "Europe/Berlin". */
     time_zone?: string;
+    /** Integrations currently loaded, e.g. "conversation". Optional because an
+     *  older frontend does not put the list on `hass`. */
+    components?: string[];
   };
+  /** The logged-in user. Optional for the same reason as the registries above:
+   *  a card must work without it rather than assume it is there. */
+  user?: {
+    is_admin?: boolean;
+    name?: string;
+  };
+  /** The profile's "keyboard shortcuts" switch. Home Assistant's own shortcut
+   *  handlers return immediately when it is off — see shared/quick-bar.ts. */
+  enableShortcuts?: boolean;
   callService: (
     domain: string,
     service: string,
@@ -2477,6 +2490,36 @@ export interface M3ApplianceCardConfig {
   card_background?: string;
   glass_background?: boolean;
   animation?: "auto" | "on" | "off";
+  radius?: number;
+  corners?: CornerRadiusConfig;
+  card_version?: string;
+}
+
+// ---- Search Card ------------------------------------------------------------
+
+export interface M3SearchCardConfig {
+  type: string;
+  /** The resting text in the bar. Defaults to a localized string that follows
+   *  `mode` — "Search Home Assistant" or "Run a command". */
+  placeholder?: string;
+  /** Alias for `placeholder`, for consistency with the cards that call their
+   *  single piece of text a `label`. `placeholder` wins if both are set. */
+  label?: string;
+  icon?: string;
+  /** Which of Home Assistant's two quick bars a tap opens. `command` needs an
+   *  admin account; see shared/quick-bar.ts for what happens without one. */
+  mode?: QuickBarMode;
+  show_assist?: boolean;
+  assist_icon?: string;
+  /** Replaces the built-in "open the search dialog" behaviour entirely, and
+   *  runs through the same handler every other card's tap_action does. */
+  tap_action?: HaActionConfig;
+  accent_color?: string;
+  text_color?: string;
+  secondary_text_color?: string;
+  card_background?: string;
+  animation?: "auto" | "on" | "off";
+  glass_background?: boolean;
   radius?: number;
   corners?: CornerRadiusConfig;
   card_version?: string;


### PR DESCRIPTION
Rebased onto current `main` — it had drifted 13 commits behind and was conflicting.

Not part of the #17/#18/#19 complaint (this one never carried the toolchain), but it was stale, so it got the same treatment while I was in there. **11 files, +1,260/−2, now mergeable.**

The only judgement call: `src/const.ts`, `src/index.ts`, `src/types.ts`, `src/localize.ts` and `CHANGELOG.md` all conflicted where `main` had gained the appliance card in the same region. Every one was additive — both sides appending to the same list — so both sides were kept.

`README.de.md` is dropped rather than resurrected, matching `main`.

### Verification

`npm run lint` clean · 195/195 tests pass (13 of them this card's own) · `npm run build` succeeds.