### PR TITLE
Smooth the wavy bars: cubic Béziers instead of straight chords

### DIFF
--- a/src/shared/wave.test.ts
+++ b/src/shared/wave.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { buildWavePath } from "./wave";
+
+// Samples a path made only of M and C commands back into points, so the
+// emitted curve can be compared against the sine it is meant to trace.
+function sampleCubics(d: string, per = 12): Array<[number, number]> {
+  const nums = (s: string) => s.trim().split(/[\s,]+/).map(Number);
+  const segs = d.split(/(?=[MC])/).filter(Boolean);
+  const [startX, startY] = nums(segs[0].slice(1));
+  let cur: [number, number] = [startX, startY];
+  const out: Array<[number, number]> = [cur];
+  for (const seg of segs.slice(1)) {
+    const [c1x, c1y, c2x, c2y, x, y] = nums(seg.slice(1));
+    const [p0x, p0y] = cur;
+    for (let i = 1; i <= per; i++) {
+      const t = i / per;
+      const u = 1 - t;
+      out.push([
+        u * u * u * p0x + 3 * u * u * t * c1x + 3 * u * t * t * c2x + t * t * t * x,
+        u * u * u * p0y + 3 * u * u * t * c1y + 3 * u * t * t * c2y + t * t * t * y,
+      ]);
+    }
+    cur = [x, y];
+  }
+  return out;
+}
+
+const AMPLITUDE = 3.5;
+const WAVELENGTH = 24;
+const MID_Y = 10;
+const sine = (x: number, phase: number) =>
+  MID_Y + AMPLITUDE * Math.sin((x / WAVELENGTH) * 2 * Math.PI + phase);
+
+describe("buildWavePath", () => {
+  it("returns nothing for a zero or negative width", () => {
+    expect(buildWavePath(0, 0, AMPLITUDE, WAVELENGTH, 0, MID_Y)).toBe("");
+    expect(buildWavePath(0, -10, AMPLITUDE, WAVELENGTH, 0, MID_Y)).toBe("");
+  });
+
+  it("draws curves rather than straight chords", () => {
+    const d = buildWavePath(0, 96, AMPLITUDE, WAVELENGTH, 0, MID_Y);
+    expect(d).toMatch(/^M/);
+    expect(d).toContain("C");
+    expect(d).not.toContain("L");
+  });
+
+  it("tracks the sine to well under a pixel", () => {
+    for (const phase of [0, 0.7, 2.4, -1.9]) {
+      const d = buildWavePath(0, 200, AMPLITUDE, WAVELENGTH, phase, MID_Y);
+      for (const [x, y] of sampleCubics(d)) {
+        expect(Math.abs(y - sine(x, phase))).toBeLessThan(0.05);
+      }
+    }
+  });
+
+  it("keeps the two halves of a split wave meeting exactly", () => {
+    // The cards draw the active and track halves as separate paths; the seam
+    // between them has to be invisible at any split point.
+    for (const split of [37.5, 61.2, 100]) {
+      const left = buildWavePath(0, split, AMPLITUDE, WAVELENGTH, 0.5, MID_Y);
+      const right = buildWavePath(split, 40, AMPLITUDE, WAVELENGTH, 0.5, MID_Y);
+      const leftPoints = sampleCubics(left);
+      const leftEnd = leftPoints[leftPoints.length - 1];
+      const rightStart = sampleCubics(right)[0];
+      expect(rightStart[0]).toBeCloseTo(leftEnd[0], 2);
+      expect(rightStart[1]).toBeCloseTo(leftEnd[1], 2);
+    }
+  });
+
+  it("collapses to a flat line at zero amplitude", () => {
+    const d = buildWavePath(0, 60, 0, WAVELENGTH, 1.1, MID_Y);
+    for (const [, y] of sampleCubics(d)) expect(y).toBeCloseTo(MID_Y, 6);
+  });
+});

--- a/src/shared/wave.ts
+++ b/src/shared/wave.ts
@@ -2,9 +2,14 @@
 // this project (progress-card's indicator, the light-card's brightness and
 // color-temperature sliders).
 
-// Builds an SVG path string for a horizontal sine wave sampled every `step`
-// px, offset by startX so it can be positioned anywhere along a longer
-// logical wave (keeps the pattern continuous across active/track splits).
+// Builds an SVG path string for a horizontal sine wave, offset by startX so
+// it can be positioned anywhere along a longer logical wave (keeps the
+// pattern continuous across active/track splits).
+//
+// The wave is sampled every `step` px, but consecutive samples are joined
+// with cubic Béziers rather than straight lines: each segment is a Hermite
+// curve built from the sine's analytic slope at both ends, so the path
+// matches the true curve instead of faceting into visible chords.
 export function buildWavePath(
   startX: number,
   widthPx: number,
@@ -15,18 +20,27 @@ export function buildWavePath(
   step = 4,
 ): string {
   if (widthPx <= 0) return "";
-  const parts: string[] = [];
-  let x = 0;
-  for (; x <= widthPx; x += step) {
-    const absX = startX + x;
-    const y =
-      midY + amplitude * Math.sin((absX / wavelength) * 2 * Math.PI + phase);
-    parts.push(`${x === 0 ? "M" : "L"}${absX.toFixed(2)},${y.toFixed(2)}`);
+  const k = (2 * Math.PI) / wavelength;
+  const yAt = (absX: number) => midY + amplitude * Math.sin(absX * k + phase);
+  const slopeAt = (absX: number) => amplitude * k * Math.cos(absX * k + phase);
+
+  const parts: string[] = [`M${startX.toFixed(2)},${yAt(startX).toFixed(2)}`];
+  for (let x = 0; x < widthPx; ) {
+    const nextX = Math.min(x + step, widthPx);
+    // A cubic's control points sit a third of the span in, displaced by the
+    // endpoint slope — that reproduces a sine arc to well under a pixel.
+    const third = (nextX - x) / 3;
+    const a = startX + x;
+    const b = startX + nextX;
+    const c1y = yAt(a) + slopeAt(a) * third;
+    const c2y = yAt(b) - slopeAt(b) * third;
+    parts.push(
+      `C${(a + third).toFixed(2)},${c1y.toFixed(2)} ` +
+        `${(b - third).toFixed(2)},${c2y.toFixed(2)} ` +
+        `${b.toFixed(2)},${yAt(b).toFixed(2)}`,
+    );
+    x = nextX;
   }
-  const absXEnd = startX + widthPx;
-  const yEnd =
-    midY + amplitude * Math.sin((absXEnd / wavelength) * 2 * Math.PI + phase);
-  parts.push(`L${absXEnd.toFixed(2)},${yEnd.toFixed(2)}`);
   return parts.join(" ");
 }
 


### PR DESCRIPTION
The wavy indicators render as polygons rather than waves, and the faceting is especially distracting while they animate.

`buildWavePath` samples the sine every 4px and joins the samples with straight `L` segments. Against the 24px wavelength every wavy bar uses, that is six flat chords per period:

![before and after](https://raw.githubusercontent.com/FezVrasta/m3-cards/pr-assets/wave-comparison.png)

## Why it is worse in motion

The sample positions are fixed in x while only their heights follow the phase, so the corners sit still and the wave slides *through* them — each corner sharpening at a peak and flattening at a zero crossing on every frame. That shimmer is layered on top of what is meant to be a smooth scroll:

![animated comparison](https://raw.githubusercontent.com/FezVrasta/m3-cards/pr-assets/wave-animated-comparison.gif)

## The change

Join the same samples with cubic Béziers. Each segment is a Hermite curve whose control points sit a third of the span in, displaced by the sine's analytic slope at both ends — so the curve follows the real function instead of an eyeballed approximation. Maximum deviation is **0.011px** on a 3.5px amplitude.

Two properties the cards depend on are preserved:

- **Split waves still meet exactly.** The active and track halves are drawn as separate paths and have to join invisibly. Every endpoint is still evaluated analytically from `startX`, so both halves anchor at an identical y — covered by a test at several arbitrary split points.
- **The signature is unchanged**, so the progress, light, media, humidifier, appliance and cover cards pick this up with no edits, including cover-card's explicit `step` argument.

The animation itself is untouched: phase still advances by `WAVE_PHASE_SPEED` per frame, which is a pure rigid translation. Only the interpolation between samples changed.

## Testing

Adds `src/shared/wave.test.ts` covering the empty-width guard, that the output contains curves and no straight chords, agreement with the sine across several phases, seam continuity for split waves, and collapse to a flat line at zero amplitude.

`npm run lint` and `npm test` (107 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CojeDiXwLWJ75DZnmL4MKL
