### PR TITLE
refactor(cards): dedupe glass-card CSS in button/climate cards

### DIFF
--- a/src/m3-button-card.ts
+++ b/src/m3-button-card.ts
@@ -23,7 +23,7 @@ import {
   resolveCornerRadius,
 } from "./const";
 import { localize, type TranslationKey } from "./localize";
-import { glassBackground } from "./shared/glass-card";
+import { glassCardStyles, glassCardClass } from "./shared/glass-card";
 import { hassChangeMatters } from "./shared/should-update";
 import { shouldAnimate, STANDARD_EASING } from "./shared/animation";
 import { migrateAnimationsField } from "./shared/config-migration";
@@ -671,9 +671,7 @@ export class M3ButtonCard extends TemplatedCard(LitElement) implements LovelaceC
         style=${`--m3-btn-color: ${color}; --m3-btn-inactive-color: ${inactiveColor}; --m3-btn-slider-fill-bg: ${sliderFillBg}; --m3-btn-icon-bg-inactive: ${iconBgInactive}; --m3-btn-icon-bg-active: ${iconBgActive}; --m3-btn-icon-bg-active-solid: ${iconBgActiveSolid}; --m3-btn-icon-ink-active: ${iconInkActive}; --m3-btn-icon-ink-inactive: ${iconInkInactive}; --m3-btn-color-fg: ${foregroundColor(this, color)}; --m3-icon-box: ${iconBoxCss}; --m3-icon-glyph: ${iconGlyphCss}; --m3-icon-offset: ${iconOffsetCss}; border-radius: ${radius};`}
       >
         <div
-          class="card-inner ${this._config.glass_background === false
-            ? "solid"
-            : "glass"} ${sliderInfo ? "sliderable" : ""} ${shouldAnimate(this._config.animation) ? "" : "no-animations"}"
+          class="card-inner ${glassCardClass(this._config.glass_background)} ${sliderInfo ? "sliderable" : ""} ${shouldAnimate(this._config.animation) ? "" : "no-animations"}"
           style=${`border-radius: ${radius};`}
           role="button"
           tabindex="0"
@@ -753,6 +751,8 @@ export class M3ButtonCard extends TemplatedCard(LitElement) implements LovelaceC
   }
 
   static styles = css`
+    ${glassCardStyles}
+
     /* Grid rather than block, and the card stretches into the grid area
        instead of taking height: 100%.
 
@@ -767,32 +767,25 @@ export class M3ButtonCard extends TemplatedCard(LitElement) implements LovelaceC
        card fills it and cqh resolves. min-height below is what gives the host
        that height when nothing else does. */
     :host {
-      /* No grey tap rectangle over a rounded card — see glass-card.ts. */
-      -webkit-tap-highlight-color: transparent;
       display: grid;
-      height: 100%;
       min-height: 56px;
     }
 
     ha-card {
-      overflow: hidden;
-      box-shadow: none;
-      background: transparent;
       container-type: size;
       transition: border-radius ${unsafeCSS(BUTTON_SHAPE_MS)}ms ${unsafeCSS(STANDARD_EASING)};
     }
 
+    /* .card-inner's glass/solid background and border come from
+       glassCardStyles. Only the layout this card differs on is set here. */
     .card-inner {
       position: relative;
       overflow: hidden;
-      box-sizing: border-box;
-      height: 100%;
-      padding: min(12px, 9cqh) min(16px, 11cqh) min(12px, 9cqh)
-        var(--m3-icon-offset, min(16px, 11cqh));
-      border: 1px solid rgba(100, 100, 100, 0.25);
+      padding: var(
+        --m3-group-padding,
+        min(12px, 9cqh) min(16px, 11cqh) min(12px, 9cqh) var(--m3-icon-offset, min(16px, 11cqh))
+      );
       cursor: pointer;
-      display: flex;
-      flex-direction: column;
       justify-content: center;
       gap: 10px;
       transition:
@@ -846,33 +839,9 @@ export class M3ButtonCard extends TemplatedCard(LitElement) implements LovelaceC
       transition: none;
     }
 
-    .card-inner.glass {
-      /* Shared value — see glassBackground in shared/glass-card.ts. */
-      background: ${glassBackground};
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      /* Forces its own compositor layer. Without this, Chromium sometimes
-         renders a visible seam where two adjacent backdrop-filter elements'
-         GPU tiles meet (flickers/disappears on scroll-triggered repaint) —
-         a known browser tiling bug, not a layout issue on our end.
-         glassCardStyles has carried this since it was found; these three
-         cards hand-roll their own copy of the rule and so never got it. */
-      transform: translateZ(0);
-      isolation: isolate;
-    }
-
-    .card-inner.solid {
-      background: var(--ha-card-background, var(--card-background-color));
-    }
-
     ha-card.unavailable .card-inner {
       opacity: 0.4;
       pointer-events: none;
-    }
-
-    .missing-entity {
-      color: var(--error-color, red);
-      font-size: 14px;
     }
 
     .content {

--- a/src/m3-climate-card-mini.ts
+++ b/src/m3-climate-card-mini.ts
@@ -17,7 +17,7 @@ import {
   THEME_COLOR_TOKENS,
 } from "./const";
 import { localize, type TranslationKey } from "./localize";
-import { glassBackground } from "./shared/glass-card";
+import { glassCardStyles, glassCardClass } from "./shared/glass-card";
 import { hassChangeMatters } from "./shared/should-update";
 import { formatNumber } from "./shared/formatting";
 import { renderMissingEntity } from "./shared/glass-card";
@@ -269,9 +269,7 @@ export class M3ClimateCardMini extends TemplatedCard(LitElement) implements Love
         class=${dimUnavailable ? "unavailable" : ""}
       >
         <div
-          class="card-inner ${this._config.glass_background === false
-            ? "solid"
-            : "glass"} ${animClass}"
+          class="card-inner ${glassCardClass(this._config.glass_background)} ${animClass}"
           style=${`border-radius: ${radius};`}
         >
           <div class="header">
@@ -364,6 +362,8 @@ export class M3ClimateCardMini extends TemplatedCard(LitElement) implements Love
   }
 
   static styles = css`
+    ${glassCardStyles}
+
     /* See the note in m3-button-card: ha-card is a size container, so a
        percentage height that does not resolve leaves it at 0. This card had no
        min-height at all, so in a masonry column it collapsed entirely — host
@@ -377,61 +377,27 @@ export class M3ClimateCardMini extends TemplatedCard(LitElement) implements Love
        for exactly those sizes. The three sizes below 112px that this does
        raise were already clipping their own content before it. */
     :host {
-      /* No grey tap rectangle over a rounded card — see glass-card.ts. */
-      -webkit-tap-highlight-color: transparent;
       display: grid;
-      height: 100%;
       min-height: 112px;
     }
 
     ha-card {
       border-radius: 28px;
-      overflow: hidden;
-      box-shadow: none;
-      background: transparent;
       container-type: size;
     }
 
+    /* .card-inner's glass/solid background and border come from
+       glassCardStyles. Only the layout this card differs on is set here. */
     .card-inner {
-      box-sizing: border-box;
-      height: 100%;
-      display: flex;
-      flex-direction: column;
       gap: 10px;
-      padding: 12px 10px;
+      padding: var(--m3-group-padding, 12px 10px);
       border-radius: 28px;
-      border: 1px solid rgba(100, 100, 100, 0.25);
-    }
-
-    .card-inner.glass {
-      /* Shared value — see glassBackground in shared/glass-card.ts. */
-      background: ${glassBackground};
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      /* Forces its own compositor layer. Without this, Chromium sometimes
-         renders a visible seam where two adjacent backdrop-filter elements'
-         GPU tiles meet (flickers/disappears on scroll-triggered repaint) —
-         a known browser tiling bug, not a layout issue on our end.
-         glassCardStyles has carried this since it was found; these three
-         cards hand-roll their own copy of the rule and so never got it. */
-      transform: translateZ(0);
-      isolation: isolate;
-    }
-
-    .card-inner.solid {
-      background: var(--ha-card-background, var(--card-background-color));
     }
 
     ha-card.unavailable .power-btn,
     ha-card.unavailable .stepper-row {
       opacity: 0.4;
       pointer-events: none;
-    }
-
-    .missing-entity {
-      padding: 16px;
-      color: var(--error-color, red);
-      font-size: 14px;
     }
 
     .header {

--- a/src/m3-climate-card.ts
+++ b/src/m3-climate-card.ts
@@ -22,7 +22,7 @@ import {
   THEME_COLOR_TOKENS,
 } from "./const";
 import { localize, type TranslationKey } from "./localize";
-import { glassBackground } from "./shared/glass-card";
+import { glassCardStyles, glassCardClass } from "./shared/glass-card";
 import { hassChangeMatters } from "./shared/should-update";
 import { formatNumber } from "./shared/formatting";
 import { renderMissingEntity } from "./shared/glass-card";
@@ -324,9 +324,7 @@ export class M3ClimateCard extends TemplatedCard(LitElement) implements Lovelace
         class=${dimUnavailable ? "unavailable" : ""}
       >
         <div
-          class="card-inner ${this._config.glass_background === false
-            ? "solid"
-            : "glass"} ${animClass}"
+          class="card-inner ${glassCardClass(this._config.glass_background)} ${animClass}"
           style=${`border-radius: ${radius}; ${heightStyle}`}
         >
           <div
@@ -547,49 +545,17 @@ export class M3ClimateCard extends TemplatedCard(LitElement) implements Lovelace
   }
 
   static styles = css`
-    :host {
-      /* No grey tap rectangle over a rounded card — see glass-card.ts. */
-      -webkit-tap-highlight-color: transparent;
-      display: block;
-      height: 100%;
-    }
+    ${glassCardStyles}
 
     ha-card {
-      height: 100%;
       border-radius: 32px;
-      overflow: hidden;
-      box-shadow: none;
-      background: transparent;
     }
 
+    /* .card-inner's glass/solid background and border come from
+       glassCardStyles. Only the layout this card differs on is set here. */
     .card-inner {
-      box-sizing: border-box;
-      height: 100%;
-      display: flex;
-      flex-direction: column;
       gap: 10px;
-      padding: 12px;
       border-radius: 32px;
-      border: 1px solid rgba(100, 100, 100, 0.25);
-    }
-
-    .card-inner.glass {
-      /* Shared value — see glassBackground in shared/glass-card.ts. */
-      background: ${glassBackground};
-      backdrop-filter: blur(20px);
-      -webkit-backdrop-filter: blur(20px);
-      /* Forces its own compositor layer. Without this, Chromium sometimes
-         renders a visible seam where two adjacent backdrop-filter elements'
-         GPU tiles meet (flickers/disappears on scroll-triggered repaint) —
-         a known browser tiling bug, not a layout issue on our end.
-         glassCardStyles has carried this since it was found; these three
-         cards hand-roll their own copy of the rule and so never got it. */
-      transform: translateZ(0);
-      isolation: isolate;
-    }
-
-    .card-inner.solid {
-      background: var(--ha-card-background, var(--card-background-color));
     }
 
     ha-card.unavailable .mode-row,
@@ -598,12 +564,6 @@ export class M3ClimateCard extends TemplatedCard(LitElement) implements Lovelace
     ha-card.unavailable .stepper-row {
       opacity: 0.4;
       pointer-events: none;
-    }
-
-    .missing-entity {
-      padding: 16px;
-      color: var(--error-color, red);
-      font-size: 14px;
     }
 
     /* Header */

--- a/src/shared/glass-card.ts
+++ b/src/shared/glass-card.ts
@@ -48,14 +48,23 @@ export const glassCardStyles = css`
     display: flex;
     flex-direction: column;
     gap: 12px;
-    padding: 12px;
-    border: 1px solid rgba(100, 100, 100, 0.25);
+    /* --m3-group-padding/-border/-background/-backdrop-filter are set by
+       m3-group-card on the container it holds its children in. They cross
+       into this shadow root the same way HA's own theme variables do (custom
+       properties inherit through shadow boundaries), so a card nested in a
+       group loses its own frame without any change to the card itself —
+       every card outside a group keeps the fallback below unchanged. Padding
+       goes to 0 in a group: the group's own gap setting is then the only
+       thing controlling space between rows, so gap: 0 means rows truly
+       touch instead of still carrying each card's own standalone padding. */
+    padding: var(--m3-group-padding, 12px);
+    border: var(--m3-group-border, 1px solid rgba(100, 100, 100, 0.25));
   }
 
   .card-inner.glass {
-    background: ${glassBackground};
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
+    background: var(--m3-group-background, ${glassBackground});
+    backdrop-filter: var(--m3-group-backdrop-filter, blur(20px));
+    -webkit-backdrop-filter: var(--m3-group-backdrop-filter, blur(20px));
     /* Forces its own compositor layer. Without this, Chromium sometimes
        renders a visible seam where two adjacent backdrop-filter elements'
        GPU tiles meet (flickers/disappears on scroll-triggered repaint) —
@@ -65,7 +74,7 @@ export const glassCardStyles = css`
   }
 
   .card-inner.solid {
-    background: var(--ha-card-background, var(--card-background-color));
+    background: var(--m3-group-background, var(--ha-card-background, var(--card-background-color)));
   }
 
   .missing-entity {


### PR DESCRIPTION
## Summary
- `m3-button-card`, `m3-climate-card` and `m3-climate-card-mini` each hand-rolled their own copy of the `.card-inner` glass/solid background rules and the glass/solid class ternary instead of using the shared `glassCardStyles`/`glassCardClass` (`shared/glass-card.ts`) that every other card in the suite uses — risking the three copies drifting apart. They now interpolate `glassCardStyles` and only override what actually differs per card (layout, border-radius, gap, custom padding formulas).
- **Small prerequisite fix bundled in, in `shared/glass-card.ts` itself**: `glassCardStyles` didn't yet carry the `--m3-group-padding`/`-border`/`-background`/`-backdrop-filter` wiring that M3 Group Card (`m3-group-card.ts`, already on `main`) relies on to strip a nested card's own frame. Without this, moving these three cards onto `glassCardStyles` would have been a visible regression for anyone nesting one of them inside a group card — right now `m3-chip-buttons-card` is the only card that supports group nesting, and it does so by hand-rolling the same `var()` wiring itself rather than through `glassCardStyles`. This PR doesn't touch that card; it only makes the shared styles support what `m3-group-card` already expects from *any* card using them.
- Zero behavior/API change otherwise — no new config options, no visual difference outside of a card nested in a group (which previously had no working shared code path for these three cards at all).

## Test plan
- [x] `npx vitest run` — 182/182 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1CFQdsZh1b4E7U3bd4G6K